### PR TITLE
Fix data bag access in config flow

### DIFF
--- a/custom_components/mitsubishi-wf-rac/config_flow.py
+++ b/custom_components/mitsubishi-wf-rac/config_flow.py
@@ -61,7 +61,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _device = None
 
             if (
-                not data[CONF_FORCE_UPDATE]
+                not data.get(CONF_FORCE_UPDATE)
                 and CONF_HOST in entry.data
                 and entry.data[CONF_HOST] in (data[CONF_HOST])
             ):


### PR DESCRIPTION
Hey buddy,

first of all: thanks for the awesome integration, I was so happy to see that someone was working on this!

I tried to setup two ACs in the same Home Assistant instance an ran into issues adding the second one:

`homeassistant    | 2022-08-09 11:03:01 ERROR (MainThread) [custom_components.mitsubishi-wf-rac.config_flow] Unexpected exception
homeassistant    | Traceback (most recent call last):
homeassistant    |   File "/config/custom_components/mitsubishi-wf-rac/config_flow.py", line 133, in async_step_discovery_confirm
homeassistant    |     info = await self._async_validate_input(self.hass, user_input)
homeassistant    |   File "/config/custom_components/mitsubishi-wf-rac/config_flow.py", line 64, in _async_validate_input
homeassistant    |     not data[CONF_FORCE_UPDATE]
homeassistant    | KeyError: 'force_update'`

I'm not a python guy, however changing the hardcoded access for the force_update key to a .get call solved the issue for me.

Hope that helps :) 