### PR TITLE
Config flow bugfix

### DIFF
--- a/custom_components/mitsubishi-wf-rac/config_flow.py
+++ b/custom_components/mitsubishi-wf-rac/config_flow.py
@@ -85,7 +85,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not result:
             raise CannotConnect
         if int(result["result"]) == 2:
-            raise ToManyDevicesRegistered
+            raise TooManyDevicesRegistered
 
         return data
 
@@ -225,7 +225,6 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def _name(self) -> str | None:
         return self.context.get(CONF_NAME)
 
-
 # pylint: disable=too-few-public-methods
 
 class KnownError(exceptions.HomeAssistantError):
@@ -273,7 +272,7 @@ class InvalidName(KnownError):
     error_name = "name_invalid"
     applies_to_field = CONF_NAME
 
-class ToManyDevicesRegistered(KnownError):
-    """Error to indicate that there are to many devices registered"""
-    error_name = "to_many_devices_registered"
+class TooManyDevicesRegistered(KnownError):
+    """Error to indicate that there are too many devices registered"""
+    error_name = "too_many_devices_registered"
     applies_to_field = CONF_BASE

--- a/custom_components/mitsubishi-wf-rac/config_flow.py
+++ b/custom_components/mitsubishi-wf-rac/config_flow.py
@@ -63,7 +63,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if (
                 not data.get(CONF_FORCE_UPDATE)
                 and CONF_HOST in entry.data
-                and entry.data[CONF_HOST] in (data[CONF_HOST])
+                and entry.data[CONF_HOST] == data[CONF_HOST]
             ):
                 # Is this address or IP address already configured?
                 already_configured = True

--- a/custom_components/mitsubishi-wf-rac/strings.json
+++ b/custom_components/mitsubishi-wf-rac/strings.json
@@ -24,7 +24,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "name_invalid": "[%key:common::config_flow::error::name_invalid%]",
       "host_already_configured": "[%key:common::config_flow::error::host_already_configured%]",
-      "to_many_devices_registered": "[%key:common::config_flow::error::to_many_devices_registered%]"
+      "too_many_devices_registered": "[%key:common::config_flow::error::too_many_devices_registered%]"
     },
     "abort": {
       "existing_instance_updated": "Updated existing configuration.",

--- a/custom_components/mitsubishi-wf-rac/strings.json
+++ b/custom_components/mitsubishi-wf-rac/strings.json
@@ -20,6 +20,7 @@
       }
     },
     "error": {
+      "unexpected_error": "[%key:common::config_flow::error::unexpected_error%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "name_invalid": "[%key:common::config_flow::error::name_invalid%]",
       "host_already_configured": "[%key:common::config_flow::error::host_already_configured%]",

--- a/custom_components/mitsubishi-wf-rac/translations/en.json
+++ b/custom_components/mitsubishi-wf-rac/translations/en.json
@@ -5,7 +5,7 @@
       "cannot_connect": "Could not connect with the Airco: {reason}",
       "name_invalid": "Name is already taken or is shorter than 3 characters",
       "host_already_configured": "Airco IP already configured as [{error_name}]",
-      "to_many_devices_registered": "There are to many devices registered for this airco. Please delete a device (in the app) or do a factory reset of the module."
+      "too_many_devices_registered": "There are too many devices registered for this airco. Please delete a device (in the app) or do a factory reset of the module."
     },
     "abort": {
       "existing_instance_updated": "Updated existing configuration.",

--- a/custom_components/mitsubishi-wf-rac/translations/en.json
+++ b/custom_components/mitsubishi-wf-rac/translations/en.json
@@ -1,9 +1,10 @@
 {
   "config": {
     "error": {
-      "cannot_connect": "Could not connect with the Airco",
+      "unexpected_error": "An unexpected error occurred. Please check the log for details.",
+      "cannot_connect": "Could not connect with the Airco: {reason}",
       "name_invalid": "Name is already taken or is shorter than 3 characters",
-      "host_already_configured": "Airco IP already configured for [{error_name}]",
+      "host_already_configured": "Airco IP already configured as [{error_name}]",
       "to_many_devices_registered": "There are to many devices registered for this airco. Please delete a device (in the app) or do a factory reset of the module."
     },
     "abort": {

--- a/custom_components/mitsubishi-wf-rac/translations/nl.json
+++ b/custom_components/mitsubishi-wf-rac/translations/nl.json
@@ -5,7 +5,7 @@
       "cannot_connect": "Kan niet verbinden met de Airco ",
       "name_invalid": "De naam is al in gebruik, of is korter dan 3 tekens. ",
       "host_already_configured": "IP is al geconfigureerd voor [{error_name}]",
-      "to_many_devices_registered": "Er zijn te veel apparaten geregistreerd op deze airco. Verwijder een apparaat of reset de module."
+      "too_many_devices_registered": "Er zijn te veel apparaten geregistreerd op deze airco. Verwijder een apparaat of reset de module."
     },
     "abort": {
       "existing_instance_updated": "Huidige configuratie is geüpdatet.",

--- a/custom_components/mitsubishi-wf-rac/translations/nl.json
+++ b/custom_components/mitsubishi-wf-rac/translations/nl.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "error": {
+      "unexpected_error": "Er is een onverwachte fout opgetreden. Raadpleeg het logboek voor details.",
       "cannot_connect": "Kan niet verbinden met de Airco ",
       "name_invalid": "De naam is al in gebruik, of is korter dan 3 tekens. ",
       "host_already_configured": "IP is al geconfigureerd voor [{error_name}]",


### PR DESCRIPTION
This fixes a bug where IP addresses were being compared by substring when adding a new device, and also some error messages were being hidden from the zeroconf-discovery config flow (I stumbled across this when adding an aircon unit, which happened to have an IP of x.x.x.21, when I already had a unit added with IP x.x.x.213).

I think the IP-substring bug might be the same problem mentioned in this comment? https://community.home-assistant.io/t/mitsubishi-wf-rac-smart-m-air/447917/3

In my case, the "host already configured" error message was not being displayed because it was added to the form with the CONF_HOST key, and in the auto-discovery config flow that field doesn't exist, so no error was shown! 
I have worked around that by factoring out the common code and having it check if a given field is in the form schema, if not it will just use CONF_BASE.