### PR TITLE
add mutex to stop multiple threads confusing the airco

### DIFF
--- a/custom_components/mitsubishi-wf-rac/config_flow.py
+++ b/custom_components/mitsubishi-wf-rac/config_flow.py
@@ -82,7 +82,8 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data[CONF_DEVICE_ID],
         )
 
-        airco_id = await hass.async_add_executor_job(repository.get_details)
+        airco_id = await hass.async_add_executor_job(repository.get_airco_id)
+
         data[CONF_AIRCO_ID] = airco_id
         if not airco_id:
             raise CannotConnect

--- a/custom_components/mitsubishi-wf-rac/sensor.py
+++ b/custom_components/mitsubishi-wf-rac/sensor.py
@@ -1,4 +1,6 @@
 """ for sensor integration."""
+# pylint: disable = too-few-public-methods
+
 from __future__ import annotations
 from datetime import timedelta
 import logging
@@ -32,7 +34,6 @@ _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
 
-
 async def async_setup_entry(hass, entry, async_add_entities):
     """Setup sensor entries"""
 
@@ -49,13 +50,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 DiagnosticsSensor(device, "Accounts", ATTR_CONNECTED_ACCOUNTS, True),
                 DiagnosticsSensor(device, "Error", CONF_ERROR),
             ]
-            if not device.airco.Electric is None:
+            if device.airco.Electric is not None:
                 entities.append(EnergySensor(device))
 
             async_add_entities(entities)
 
-
 class DiagnosticsSensor(SensorEntity):
+    # pylint: disable = too-many-instance-attributes
     """Representation of a Sensor."""
 
     _attr_entity_category: EntityCategory | None = EntityCategory.DIAGNOSTIC

--- a/custom_components/mitsubishi-wf-rac/wfrac/device.py
+++ b/custom_components/mitsubishi-wf-rac/wfrac/device.py
@@ -60,7 +60,7 @@ class Device:  # pylint: disable=too-many-instance-attributes
                 return
         except Exception as ex:  # pylint: disable=broad-except
             _LOGGER.error(
-                "Error: something whent wrong updating the airco [%s] valus - error: %s",
+                "Error: something went wrong updating the airco [%s] valus - error: %s",
                 self.name,
                 ex,
             )
@@ -121,8 +121,9 @@ class Device:  # pylint: disable=too-many-instance-attributes
                 self._airco_id,
                 _command,
             )
-        except Exception as ex:  # pylint: disable=broad-except
-            _LOGGER.debug("Could not send airco data %s", ex)
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Could not send airco data")
+            return
 
         self._airco = self._parser.translate_bytes(_raw_response)
 

--- a/custom_components/mitsubishi-wf-rac/wfrac/repository.py
+++ b/custom_components/mitsubishi-wf-rac/wfrac/repository.py
@@ -1,7 +1,17 @@
 """Local API for sending and receiving to and from WF-RAC module"""
+from __future__ import annotations
 
 import time
-from requests import post
+import logging
+import threading
+import requests
+
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+# log http requests/responses to separate logger, to allow easily turning on/off from
+# configuration.yaml
+_HTTP_LOG = _LOGGER.getChild("http")
 
 
 class Repository:
@@ -16,80 +26,69 @@ class Repository:
         self._port = port
         self._operator_id = operator_id
         self._device_id = device_id
+        self._mutex = threading.Lock()
 
-    def get_details(self) -> str:
-        """Simple command to get aircon details"""
-        url = f"http://{self._hostname}:{self._port}/beaver/command/getDeviceInfo"
-        myobj = {
+    def _post(self,
+              command: str,
+              contents: dict[str, Any] | None = None) -> dict:
+        url = f"http://{self._hostname}:{self._port}/beaver/command/{command}"
+        data = {
             "apiVer": self.api_version,
-            "command": "getDeviceInfo",
+            "command": command,
             "deviceId": self._device_id,  # is unique device ID (on android it is called android_id)
             "operatorId": self._operator_id,  # is generated UUID
             "timestamp": round(time.time()),
         }
+        if contents is not None:
+            data["contents"] = contents
 
-        return post(url, json=myobj).json()["contents"]["airconId"]
+        # ensure only one thread is talking to the device at a time
+        with self._mutex:
+            _HTTP_LOG.debug("POSTing to %s: %r", url, data)
+            response = requests.post(url, json=data)
+            _HTTP_LOG.debug("Got response (%r): %r", response.status_code, response.text)
+
+        # raise an exception if the airco returned an error
+        response.raise_for_status()
+
+        return response.json()
+
+    def get_info(self) -> str:
+        """Simple command to get aircon details"""
+        return self._post("getDeviceInfo")["contents"]
+
+    def get_airco_id(self) -> str:
+        """Simple command to get aircon ID"""
+        return self.get_info()["airconId"]
 
     def update_account_info(self, airco_id: str, time_zone: str) -> str:
         """Update the account info on the airco (sets to operator id of the device)"""
-        url = f"http://{self._hostname}:{self._port}/beaver/command/updateAccountInfo"
-        myobj = {
-            "apiVer": self.api_version,
-            "command": "updateAccountInfo",
-            "deviceId": self._device_id,  # is unique device ID (on android it is called android_id)
-            "operatorId": self._operator_id,  # is generated UUID
-            "contents": {
-                "accountId": self._operator_id,
-                "airconId": airco_id,
-                "remote": 0,
-                "timezone": time_zone,
-            },
-            "timestamp": round(time.time()),
+        contents = {
+            "accountId": self._operator_id,
+            "airconId": airco_id,
+            "remote": 0,
+            "timezone": time_zone,
         }
-
-        return post(url, json=myobj).json()
+        return self._post("updateAccountInfo", contents)
 
     def del_account_info(self, airco_id: str) -> str:
         """delete the account info on the airco"""
-        url = f"http://{self._hostname}:{self._port}/beaver/command/deleteAccountInfo"
-        myobj = {
-            "apiVer": self.api_version,
-            "command": "deleteAccountInfo",
-            "deviceId": self._device_id,  # is unique device ID (on android it is called android_id)
-            "operatorId": self._operator_id,  # is generated UUID
-            "contents": {"accountId": self._operator_id, "airconId": airco_id},
-            "timestamp": round(time.time()),
+        contents = {
+            "accountId": self._operator_id,
+            "airconId": airco_id
         }
-
-        return post(url, json=myobj).json()
+        return self._post("deleteAccountInfo", contents)
 
     def get_aircon_stats(self, raw=False) -> str:
         """Get the Aricon Stats from the Airco"""
-        url = f"http://{self._hostname}:{self._port}/beaver/command/getAirconStat"
-        myobj = {
-            "apiVer": self.api_version,
-            "command": "getAirconStat",
-            "deviceId": self._device_id,  # is unique device ID (on android it is called android_id)
-            "operatorId": self._operator_id,  # is generated UUID
-            "timestamp": round(time.time()),
-        }
-
-        if raw is True:
-            return post(url, json=myobj).json()
-
-        return post(url, json=myobj).json()["contents"]
+        result = self._post("getAirconStat")
+        return result if raw else result["contents"]
 
     def send_airco_command(self, airco_id: str, command: str) -> str:
         """send command to the Airco"""
-        url = f"http://{self._hostname}:{self._port}/beaver/command/setAirconStat"
-        myobj = {
-            "apiVer": self.api_version,
-            "command": "setAirconStat",
-            "contents": {"airconId": airco_id, "airconStat": command},
-            "deviceId": self._device_id,  # is unique device ID (on android it is called android_id)
-            "operatorId": self._operator_id,  # is generated UUID
-            "timestamp": round(time.time()),
+        contents = {
+            "airconId": airco_id,
+            "airconStat": command
         }
-
-        # return post(url, json=myobj).json()
-        return post(url, json=myobj).json()["contents"]["airconStat"]
+        result = self._post("setAirconStat", contents)
+        return result["contents"]["airconStat"]


### PR DESCRIPTION
I noticed if I mash the buttons in home assistant to turn an aircon unit on+off/set temp/etc very quickly, the device will get confused and reject a lot of the requests.

I added some more debug logging to see what was going on, and it seems that home assistant was running the POSTs from multiple threads at the ~same time, and the aircon was replying with status 501 and the text "Not supported this command"

eg here you can see two threads POSTing to the same device, causing one of the threads to receive a 501 response
```
2022-09-06 18:52:23.208 DEBUG (SyncWorker_8) [custom_components.mitsubishi-wf-rac.wfrac.repository] (thread 140148970076976) POSTing to http://10.8.4.118:51443/beaver/command/setAirconStat: [...]
2022-09-06 18:52:23.637 DEBUG (SyncWorker_0) [custom_components.mitsubishi-wf-rac.wfrac.repository] (thread 140149305355056) POSTing to http://10.8.4.118:51443/beaver/command/setAirconStat: [...]
2022-09-06 18:52:23.912 DEBUG (SyncWorker_5) [custom_components.mitsubishi-wf-rac.wfrac.repository] (thread 140149198629680) Got response (200): '{"command":"setAirconStat",[...]
2022-09-06 18:52:24.069 DEBUG (SyncWorker_8) [custom_components.mitsubishi-wf-rac.wfrac.repository] (thread 140148970076976) Got response (501): 'Not supported this command'
```

To solve that I've added a lock to the Repository instance, so the threads access the aircon device one at a time.

I also refactored Repository slightly so it's easy to control all the POSTs from one place, and added a minimum time between requests (currently 1s) to try to ensure we won't overwhelm the unit's http server.

For now the waiting is done via a simple time.sleep() but I don't think it will be too difficult to make the Repository code async so we can wait without wasting a thread…