### PR TITLE
convert Repository functions to async

### DIFF
--- a/custom_components/mitsubishi-wf-rac/config_flow.py
+++ b/custom_components/mitsubishi-wf-rac/config_flow.py
@@ -59,6 +59,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 raise HostAlreadyConfigured(error_name=existing_entry.data[CONF_NAME])
 
         repository = Repository(
+            hass,
             data[CONF_HOST],
             data[CONF_PORT],
             data[CONF_OPERATOR_ID],
@@ -66,7 +67,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         try:
-            airco_id = await hass.async_add_executor_job(repository.get_details)
+            airco_id = await repository.get_airco_id()
         except Exception as query_failed:
             raise CannotConnect(reason=str(query_failed)) from query_failed
 
@@ -79,9 +80,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data[CONF_OPERATOR_ID],
             data[CONF_AIRCO_ID],
         )
-        result = await hass.async_add_executor_job(
-            repository.update_account_info, airco_id, hass.config.time_zone
-        )
+        result = await repository.update_account_info(airco_id, hass.config.time_zone)
         if not result:
             raise CannotConnect
         if int(result["result"]) == 2:

--- a/custom_components/mitsubishi-wf-rac/wfrac/repository.py
+++ b/custom_components/mitsubishi-wf-rac/wfrac/repository.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 
 import time
 import logging
-import threading
+import asyncio
+import functools
 
 from typing import Any
 from datetime import datetime, timedelta
+from homeassistant.helpers.typing import HomeAssistantType
 
 import requests
 
@@ -24,19 +26,25 @@ class Repository:
 
     api_version = "1.0"
 
-    def __init__(
-        self, hostname: str, port: int, operator_id: str, device_id: str
+    def __init__(  # pylint: disable=too-many-arguments
+            self,
+            hass: HomeAssistantType,
+            hostname: str,
+            port: int,
+            operator_id: str,
+            device_id: str
     ) -> None:
+        self._hass = hass
         self._hostname = hostname
         self._port = port
         self._operator_id = operator_id
         self._device_id = device_id
-        self._mutex = threading.Lock()
+        self._mutex = asyncio.Lock()
         self._next_request_after = datetime.now()
 
-    def _post(self,
-              command: str,
-              contents: dict[str, Any] | None = None) -> dict:
+    async def _post(self,
+                    command: str,
+                    contents: dict[str, Any] | None = None) -> dict:
         url = f"http://{self._hostname}:{self._port}/beaver/command/{command}"
         data = {
             "apiVer": self.api_version,
@@ -49,37 +57,40 @@ class Repository:
             data["contents"] = contents
 
         # ensure only one thread is talking to the device at a time
-        with self._mutex:
+        async with self._mutex:
             wait_for = (self._next_request_after - datetime.now()).total_seconds()
             if wait_for > 0:
-                _LOGGER.debug("Waiting for %r until we can send a request", wait_for)
-                # TODO: make this whole thing async so we don't
-                # actually tie up a thread while we wait
-                time.sleep(wait_for)
+                _LOGGER.debug("Waiting for %rs until we can send a request", wait_for)
+                await asyncio.sleep(wait_for)
+
             _HTTP_LOG.debug("POSTing to %s: %r",
                             url,
                             data)
-            response = requests.post(url, json=data)
+            response = await self._hass.async_add_executor_job(
+                functools.partial(requests.post, url, json=data))
+
             _HTTP_LOG.debug("Got response (%r) from %r: %r",
                             response.status_code,
                             self._hostname,
                             response.text)
+
+            # remember to set the next request time before we release the lock!
             self._next_request_after = datetime.now() + _MIN_TIME_BETWEEN_REQUESTS
 
-        # raise an exception if the airco returned an error
+        # raise an exception if the airco returned an error, let the caller figure it out
         response.raise_for_status()
 
         return response.json()
 
-    def get_info(self) -> str:
+    async def get_info(self) -> str:
         """Simple command to get aircon details"""
-        return self._post("getDeviceInfo")["contents"]
+        return (await self._post("getDeviceInfo"))["contents"]
 
-    def get_airco_id(self) -> str:
+    async def get_airco_id(self) -> str:
         """Simple command to get aircon ID"""
-        return self.get_info()["airconId"]
+        return (await self.get_info())["airconId"]
 
-    def update_account_info(self, airco_id: str, time_zone: str) -> str:
+    async def update_account_info(self, airco_id: str, time_zone: str) -> str:
         """Update the account info on the airco (sets to operator id of the device)"""
         contents = {
             "accountId": self._operator_id,
@@ -87,26 +98,26 @@ class Repository:
             "remote": 0,
             "timezone": time_zone,
         }
-        return self._post("updateAccountInfo", contents)
+        return await self._post("updateAccountInfo", contents)
 
-    def del_account_info(self, airco_id: str) -> str:
+    async def del_account_info(self, airco_id: str) -> str:
         """delete the account info on the airco"""
         contents = {
             "accountId": self._operator_id,
             "airconId": airco_id
         }
-        return self._post("deleteAccountInfo", contents)
+        return await self._post("deleteAccountInfo", contents)
 
-    def get_aircon_stats(self, raw=False) -> str:
+    async def get_aircon_stats(self, raw=False) -> str:
         """Get the Aricon Stats from the Airco"""
-        result = self._post("getAirconStat")
+        result = await self._post("getAirconStat")
         return result if raw else result["contents"]
 
-    def send_airco_command(self, airco_id: str, command: str) -> str:
+    async def send_airco_command(self, airco_id: str, command: str) -> str:
         """send command to the Airco"""
         contents = {
             "airconId": airco_id,
             "airconStat": command
         }
-        result = self._post("setAirconStat", contents)
+        result = await self._post("setAirconStat", contents)
         return result["contents"]["airconStat"]


### PR DESCRIPTION
This should have ~0 functional effect; this just stops us (potentially) blocking a thread while we query the aircon device (and while waiting to query) by converting the repository functions to use `async`. 
