### PR TITLE
Fixed bug when setting swing modes.

### DIFF
--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -134,7 +134,7 @@ class AircoClimate(ClimateEntity):
         _airco = self._device.airco
         _swing_auto = swing_mode == SWING_3D_AUTO
         _swing_lr = (
-            SWING_HORIZONTAL_AUTO
+            HORIZONTAL_SWING_MODE_TRANSLATION[SWING_HORIZONTAL_AUTO]
             if self._device.airco.Entrust
             else self._device.airco.WindDirectionLR
         )
@@ -157,7 +157,7 @@ class AircoClimate(ClimateEntity):
         _airco = self._device.airco
         _swing_lr = HORIZONTAL_SWING_MODE_TRANSLATION[swing_mode]
         _swing_ud = (
-            SWING_VERTICAL_AUTO
+            HORIZONTAL_SWING_MODE_TRANSLATION[SWING_VERTICAL_AUTO]
             if self._device.airco.Entrust
             else self._device.airco.WindDirectionUD
         )


### PR DESCRIPTION
In async_set_swing_mode() and async_set_horizontal_swing_mode(), _swing_lr and _swing_ud get incorrectly set to strings instead of the translated (integer) values.

This causes the command to be incorrectly encoded and the A/C unit responds with HTTP 501 .