### PR TITLE
Add new `ClimateEntityFeature` flags to fix warnings on 2024.2

### DIFF
--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -83,6 +83,7 @@ class AircoClimate(ClimateEntity):
     # _attr_horizontal_swing_modes: list[str] | None = SUPPORT_HORIZONTAL_SWING_MODES
     _attr_min_temp: float = 16
     _attr_max_temp: float = 30
+    _enable_turn_on_off_backwards_compatibility = False  # Remove after HA 2025.1
 
     def __init__(self, device: Device, hass:HomeAssistantType) -> None:
         self._device = device

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -38,9 +38,11 @@ SERVICE_SET_HORIZONTAL_SWING_MODE = "set_horizontal_swing_mode"
 SERVICE_SET_VERTICAL_SWING_MODE = "set_vertical_swing_mode"
 
 SUPPORT_FLAGS = (
-    ClimateEntityFeature.TARGET_TEMPERATURE
+    ClimateEntityFeature.FAN_MODE
     | ClimateEntityFeature.SWING_MODE
-    | ClimateEntityFeature.FAN_MODE
+    | ClimateEntityFeature.TARGET_TEMPERATURE
+    | ClimateEntityFeature.TURN_OFF
+    | ClimateEntityFeature.TURN_ON
 )
 
 SUPPORTED_HVAC_MODES = [


### PR DESCRIPTION
HA 2024.2 added 2 new `ClimateEntityFeature` flags (`TURN_ON` and `TURN_OFF`). This PR adapts to that change.

More info: https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded/

Fixes #78 