### PR TITLE
Config flow changes

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -64,6 +64,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEnt
 
     return True
 
+async def async_unload_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEntry) -> bool:
+    """Handle unload of entry."""
+
+    # Unload entities for this entry/device.
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    return unload_ok
+
 
 async def async_remove_entry(hass, entry: MitsubishiWfRacConfigEntry) -> None:
     """Handle removal of an entry."""

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
+from . import MitsubishiWfRacConfigEntry
 import voluptuous as vol
 
 from homeassistant.components.climate import ClimateEntity
@@ -14,7 +15,6 @@ from homeassistant.components.climate.const import HVACMode, FAN_AUTO
 from homeassistant.const import UnitOfTemperature, ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
 from homeassistant.util import Throttle
-from homeassistant.const import CONF_HOST
 from homeassistant.helpers import config_validation as cv, entity_platform
 
 from .wfrac.device import MIN_TIME_BETWEEN_UPDATES, Device
@@ -40,12 +40,11 @@ _LOGGER = logging.getLogger(__name__)
 UPDATE_CONSOLIDATION_PERIOD = timedelta(milliseconds=500)
 
 
-async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities):
+async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_entities):
     """Setup climate entities"""
-    for device in hass.data[DOMAIN]:
-        if device.host == entry.options[CONF_HOST]:
-            _LOGGER.info("Setup climate for: %s, %s", device.name, device.airco_id)
-            async_add_entities([AircoClimate(device, hass)])
+    device: Device = entry.runtime_data.device
+    _LOGGER.info("Setup climate for: %s, %s", device.name, device.airco_id)
+    async_add_entities([AircoClimate(device, hass)])
 
     platform = entity_platform.async_get_current_platform()
 

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -3,8 +3,8 @@
 
 import logging
 
+from . import MitsubishiWfRacConfigEntry
 from homeassistant.components.select import SelectEntity
-from homeassistant.const import CONF_HOST
 
 from .wfrac.models.aircon import AirconCommands
 from .wfrac.device import Device
@@ -19,15 +19,14 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_entities):
     """Setup select entries"""
 
-    for device in hass.data[DOMAIN]:
-        if device.host == entry.options[CONF_HOST]:
-            _LOGGER.info("Setup Horizontal and Vertical Select: %s, %s", device.name, device.airco_id)
-            entities = [HorizontalSwingSelect(device), VerticalSwingSelect(device)]
+    device: Device = entry.runtime_data.device
+    _LOGGER.info("Setup Horizontal and Vertical Select: %s, %s", device.name, device.airco_id)
+    entities = [HorizontalSwingSelect(device), VerticalSwingSelect(device)]
 
-            async_add_entities(entities)
+    async_add_entities(entities)
 
 
 class HorizontalSwingSelect(SelectEntity):

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
+from . import MitsubishiWfRacConfigEntry
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
@@ -33,27 +34,27 @@ _LOGGER = logging.getLogger(__name__)
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_entities):
     """Setup sensor entries"""
 
-    for device in hass.data[DOMAIN]:
-        if device.host == entry.options[CONF_HOST]:
-            _LOGGER.info("Setup: %s, %s", device.name, device.airco_id)
-            entities = [
-                TemperatureSensor(device, "Indoor", ATTR_INSIDE_TEMPERATURE),
-                TemperatureSensor(device, "Outdoor", ATTR_OUTSIDE_TEMPERATURE),
-                TemperatureSensor(device, "Target", ATTR_TARGET_TEMPERATURE, False),
-                DiagnosticsSensor(device, "Airco ID", CONF_AIRCO_ID),
-                DiagnosticsSensor(device, "Operator ID", CONF_OPERATOR_ID, True),
-                DiagnosticsSensor(device, "Device ID", ATTR_DEVICE_ID, True),
-                DiagnosticsSensor(device, "IP", CONF_HOST, True),
-                DiagnosticsSensor(device, "Accounts", ATTR_CONNECTED_ACCOUNTS, True),
-                DiagnosticsSensor(device, "Error", CONF_ERROR),
-            ]
-            if device.airco.Electric is not None:
-                entities.append(EnergySensor(device))
+    device: Device = entry.runtime_data.device
 
-            async_add_entities(entities)
+    _LOGGER.info("Setup: %s, %s", device.name, device.airco_id)
+    entities = [
+        TemperatureSensor(device, "Indoor", ATTR_INSIDE_TEMPERATURE),
+        TemperatureSensor(device, "Outdoor", ATTR_OUTSIDE_TEMPERATURE),
+        TemperatureSensor(device, "Target", ATTR_TARGET_TEMPERATURE, False),
+        DiagnosticsSensor(device, "Airco ID", CONF_AIRCO_ID),
+        DiagnosticsSensor(device, "Operator ID", CONF_OPERATOR_ID, True),
+        DiagnosticsSensor(device, "Device ID", ATTR_DEVICE_ID, True),
+        DiagnosticsSensor(device, "IP", CONF_HOST, True),
+        DiagnosticsSensor(device, "Accounts", ATTR_CONNECTED_ACCOUNTS, True),
+        DiagnosticsSensor(device, "Error", CONF_ERROR),
+    ]
+    if device.airco.Electric is not None:
+        entities.append(EnergySensor(device))
+
+    async_add_entities(entities)
 
 
 class DiagnosticsSensor(SensorEntity):


### PR DESCRIPTION
Hi,

I've added support for the new runtime data storage inside the config entries instead of hass.data[DOMAIN] (https://developers.home-assistant.io/blog/2024/04/30/store-runtime-data-inside-config-entry/). Furthermore, I've added the option to unload the config entry (just cleaning all entities) to make it possible to reload the config entry from the UI (for example when the AC became unavailable after cutting its power). Currently, you have to restart Home Assistant to reload the integration.

If there is anything I need to do, please let me know!

Thanks in advance!

Kind regards,
Wesley Vos