### PR TITLE
Combine HTTPS functionality with refactor/use aiohttp

### DIFF
--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     CONF_FORCE_UPDATE,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.config_entries import ConfigFlowResult
 
 from .const import CONF_AVAILABILITY_CHECK, CONF_AVAILABILITY_RETRY_LIMIT, CONF_OPERATOR_ID, CONF_AIRCO_ID, DOMAIN, \
     CONF_CREATE_SWING_MODE_SELECT
@@ -232,7 +232,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_zeroconf(
             self, discovery_info: zeroconf.ZeroconfServiceInfo
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle zeroconf discovery."""
 
         local_name = discovery_info.hostname.rstrip(".")

--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -11,7 +11,7 @@
   "requirements": [
     "aenum>=3.1.11"
   ],
-  "version": "2024.7",
+  "version": "2024.12",
   "zeroconf": [
     "_beaver._tcp.local."
   ]

--- a/custom_components/mitsubishi_wf_rac/services.yaml
+++ b/custom_components/mitsubishi_wf_rac/services.yaml
@@ -72,3 +72,28 @@ set_vertical_swing_mode:
             - "Normal"
             - "Lowest"
             - "3D Auto"
+# Service ID
+set_fan_speed:
+  # Service name as shown in UI
+  name: Set fan speed
+  # Description of the service
+  description: Sets the fan speed of the air conditioner
+  target:
+    device:
+      integration: mitsubishi_wf_rac
+  fields:
+    speed:
+      name: Fan speed
+      description: Which fan speed to set
+      required: true
+      advanced: false
+      example: "Auto"
+      default: "Auto"
+      selector:
+        select:
+          options:
+            - "Auto"
+            - "1 Lowest"
+            - "2 Low"
+            - "3 High"
+            - "4 Highest"

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Smart M-Air (Mitsubishi WF-RAC)",
-  "homeassistant": "2024.6",
+  "homeassistant": "2024.12",
   "render_readme": true
 }


### PR DESCRIPTION
Given my pull request for HTTPS functionality is incompatible with the other pull request to use aiohttp, #147 , I've tried combining the two. Working well on my new unit that requires HTTPS to work.

### Key features:
- Automatically discovers if the unit uses HTTP or HTTPS.
- If HTTPS is used, it checks for a user-provided ac_cert.pem file.
- If the certificate exists, it creates a secure, validated SSL connection (with hostname checking disabled, which is required for these devices).
- If no certificate exists, it falls back to an insecure HTTPS connection.

Certificate file can be generated by running
`openssl s_client -connect {{IP_OF_AC}}:51443 -showcerts </dev/null 2>/dev/null | openssl x509 -outform PEM > ac_cert.pem
`

This should (hopefully) make the integration work for both old and new models, securely and automatically.

I'm new to contributing, so I'm happy to make any changes or answer any questions. Thanks!