### PR TITLE
Use standard fan speed definitions with icons

### DIFF
--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.components.climate.const import HVACMode, FAN_AUTO
+from homeassistant.components.climate.const import HVACMode, FAN_AUTO, FAN_LOW, FAN_MEDIUM, FAN_HIGH
 from homeassistant.const import UnitOfTemperature, ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
 from homeassistant.util import Throttle

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -6,6 +6,9 @@ from homeassistant.components.climate.const import (
     HVACMode,
     ClimateEntityFeature,
     FAN_AUTO,
+    FAN_LOW,
+    FAN_MEDIUM,
+    FAN_HIGH,
 )
 
 DOMAIN = "mitsubishi_wf_rac"
@@ -127,25 +130,22 @@ SUPPORT_SWING_HORIZONTAL_MODES = [
 ]
 
 
-FAN_MODE_1 = "1 Lowest"
-FAN_MODE_2 = "2 Low"
-FAN_MODE_3 = "3 High"
-FAN_MODE_4 = "4 Highest"
+FAN_QUIET = "Quiet"
 
 FAN_MODE_TRANSLATION = {
     FAN_AUTO: 0,
-    FAN_MODE_1: 1,
-    FAN_MODE_2: 2,
-    FAN_MODE_3: 3,
-    FAN_MODE_4: 4,
+    FAN_QUIET: 1,
+    FAN_LOW: 2,
+    FAN_MEDIUM: 3,
+    FAN_HIGH: 4,
 }
 
 SUPPORTED_FAN_MODES = [
     FAN_AUTO,
-    FAN_MODE_1,
-    FAN_MODE_2,
-    FAN_MODE_3,
-    FAN_MODE_4,
+    FAN_QUIET,
+    FAN_LOW,
+    FAN_MEDIUM,
+    FAN_HIGH,
 ]
 
 

--- a/custom_components/mitsubishi_wf_rac/services.yaml
+++ b/custom_components/mitsubishi_wf_rac/services.yaml
@@ -93,7 +93,7 @@ set_fan_speed:
         select:
           options:
             - "Auto"
-            - "1 Lowest"
-            - "2 Low"
-            - "3 High"
-            - "4 Highest"
+            - "Quiet"
+            - "Low"
+            - "Medium"
+            - "High"


### PR DESCRIPTION
Use standard fan speed definitions with icons - fix #155

Uses fan speed definitions from the climate component where possible and adds a definition for Quiet mode. This more closely matches the terminology used in the air conditioner user manuals. Additionally the changes also enable suitable icons for the individual fan modes.
