### PR TITLE
self.config_entry = config_entry. This will stop working in Home Assi…

### DIFF
--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -272,7 +272,7 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
+        self._conf_app_id: str | None = None
 
     async def async_step_init(
             self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
The current flow will stop working in Home Assistant. Therefore this change
Refactor initialization to include app ID as a class attribute.

def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
        """Initialize options flow."""
          self._conf_app_id: str | None = None