### PR TITLE
Fix intermittent disconnects (poll timeout + account re-registration)

### DIFF
--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -77,6 +77,13 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             _LOGGER.warning(
                 "Error: something went wrong updating the airco [%s] values", self.device_name
             )
+            # The WF-RAC module keeps only a small, fixed-size table of registered
+            # accounts (operator ids). Opening the official app or adding phones can
+            # silently evict Home Assistant from that table, after which polls fail
+            # until the integration is reloaded. Proactively re-register our account
+            # on failure so we recover automatically on the next poll if we were
+            # evicted. add_account() is self-contained and swallows its own errors.
+            await self.add_account()
             return
 
         try:
@@ -212,7 +219,11 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
     async def _async_update_data(self):
         """Update data via library."""
         try:
-            async with timeout(10):
+            # Match the underlying HTTP request timeout (30s). The WF-RAC adapter
+            # is slow/flaky and frequently answers in 10-20s; a tighter coordinator
+            # timeout here would cancel slow-but-valid polls and mark the entity
+            # unavailable even though the unit was about to respond.
+            async with timeout(30):
                 await asyncio.gather(*[self.update()])
         except Exception as error:
             raise UpdateFailed(error) from error


### PR DESCRIPTION
Addresses the recurring "entity goes unavailable from time to time while the official (cloud) app is fine" reports. The official app talks to the unit via the cloud, so it stays fine even when the local path HA uses has a hiccup. Two local causes, both fixed in `wfrac/device.py`:

**1. Coordinator timeout shorter than the request timeout**
`_async_update_data` wrapped each poll in a 10s timeout, while the underlying HTTP request allows 30s (`repository.py`). The WF-RAC adapter is slow/flaky and frequently answers in 10-20s, so valid polls were being cancelled and the entity marked unavailable even though the unit was about to respond. Raised the coordinator timeout to 30s to match.

**2. Silent eviction from the module account table**
The WF-RAC module keeps only a small, fixed-size table of registered accounts (operator ids). Opening the official app or registering extra phones can evict Home Assistant, after which polls fail until the integration is manually reloaded. We now re-register the account on poll failure (`add_account()`, which already swallows its own errors), so HA self-recovers on the next cycle if it was evicted.

No config/schema changes; both are minimal and behind existing code paths.