### PR TITLE
Fix availability_retry option key mismatch

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -91,7 +91,12 @@ async def create_device_from_entry(entry, hass):
     operator_id: str = entry.data[CONF_OPERATOR_ID]
     port: int = entry.data[CONF_PORT]
     airco_id: str = entry.data[CONF_AIRCO_ID]
-    availability_retry: bool = entry.options.get("availability_retry", False)
+    # Bugfix: config_flow.py stores this toggle under CONF_AVAILABILITY_CHECK
+    # ("availability_check") via the Options Flow; the literal "availability_retry"
+    # key is never written anywhere, so this always defaulted to False and the
+    # retry-tolerance logic in wfrac/device.py (_availability_retry_limit) was
+    # dead code even when the user enabled "Availability Check" in the UI.
+    availability_retry: bool = entry.options.get(CONF_AVAILABILITY_CHECK, False)
     availability_retry_limit: int = entry.options.get(CONF_AVAILABILITY_RETRY_LIMIT, 3)
     create_swing_mode_select: bool = entry.data.get(CONF_CREATE_SWING_MODE_SELECT, True)
     _device = Device(hass, name, device, port, device_id, operator_id, airco_id, availability_retry,


### PR DESCRIPTION
## Summary

`create_device_from_entry()` in `__init__.py` reads:

```python
availability_retry: bool = entry.options.get("availability_retry", False)
```

But the Options Flow (`config_flow.py`) stores this toggle under `CONF_AVAILABILITY_CHECK` (`"availability_check"`) instead - the literal `"availability_retry"` key is never written anywhere in the codebase. As a result, `self._availability_retry` in `wfrac/device.py` always defaulted to `False`, regardless of what the user configured for "Availability Check" in the integration options.

This leaves the retry-tolerance logic in `Device._set_availability()` (gated by `availability_retry_limit`) permanently dead: every single failed poll immediately flips the entity to `unavailable`, instead of only after `availability_retry_limit` consecutive failures as intended.

## Fix

```diff
-    availability_retry: bool = entry.options.get("availability_retry", False)
+    availability_retry: bool = entry.options.get(CONF_AVAILABILITY_CHECK, False)
```

One line - reads the option key that is actually written by the Options Flow.

## Context / motivation

Noticed while investigating intermittent `unavailable` states on two WF-RAC units. Router-level WiFi client logs showed both devices disconnect/reconnect their own WiFi in a stable, independent ~60-minute cycle (consistent with a firmware keepalive/watchdog), with the actual network blip lasting only ~1-25s. With `availability_retry` correctly wired up and `availability_retry_limit` at its default of 3, the coordinator (60s poll interval) now tolerates a couple of failed polls before marking the entity unavailable, which comfortably rides through these short reconnects instead of surfacing them as outages.

## Test plan

- [x] Applied locally against two live WF-RAC climate entities (running Home Assistant 2026.7.2)
- [x] Confirmed the Options Flow value (`availability_check: true`) is now actually read and respected
- [x] Longer-term confirmation that hourly unavailable blips no longer surface - confirmed over an ~11h window post-patch: the underlying WiFi reconnects/poll failures still occur at the same hourly cadence (log warnings unchanged), but the entities' recorded history shows zero `unavailable` transitions in that window - the retry tolerance is absorbing them as intended