### PR TITLE
Fix intermittent disconnects: combine #193 + #200, plus exception logging and command-send fix

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -91,7 +91,12 @@ async def create_device_from_entry(entry, hass):
     operator_id: str = entry.data[CONF_OPERATOR_ID]
     port: int = entry.data[CONF_PORT]
     airco_id: str = entry.data[CONF_AIRCO_ID]
-    availability_retry: bool = entry.options.get("availability_retry", False)
+    # Bugfix: config_flow.py stores this toggle under CONF_AVAILABILITY_CHECK
+    # ("availability_check") via the Options Flow; the literal "availability_retry"
+    # key is never written anywhere, so this always defaulted to False and the
+    # retry-tolerance logic in wfrac/device.py (_availability_retry_limit) was
+    # dead code even when the user enabled "Availability Check" in the UI.
+    availability_retry: bool = entry.options.get(CONF_AVAILABILITY_CHECK, False)
     availability_retry_limit: int = entry.options.get(CONF_AVAILABILITY_RETRY_LIMIT, 3)
     create_swing_mode_select: bool = entry.data.get(CONF_CREATE_SWING_MODE_SELECT, True)
     _device = Device(hass, name, device, port, device_id, operator_id, airco_id, availability_retry,

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -191,7 +191,16 @@ class AircoClimate(ClimateEntity):
         await asyncio.sleep(UPDATE_CONSOLIDATION_PERIOD.total_seconds())
         params = self._consolidated_params.copy()
         self._consolidated_params.clear()
-        await self._device.set_airco(params)
+        try:
+            await self._device.set_airco(params)
+        except Exception:  # pylint: disable=broad-except
+            # This runs as a detached task (async_create_task, nothing awaits it), so
+            # without this the re-raised error from Device.set_airco() (already logged
+            # there) becomes an orphaned "Task exception was never retrieved" with zero
+            # HA-visible feedback that the command never reached the unit. Still refresh
+            # below so the entity picks up self._device.available if the same failure
+            # already flipped it.
+            pass
         self._update_state()
         self.async_write_ha_state()
 

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -77,6 +77,13 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             _LOGGER.warning(
                 "Error: something went wrong updating the airco [%s] values", self.device_name
             )
+            # The WF-RAC module keeps only a small, fixed-size table of registered
+            # accounts (operator ids). Opening the official app or adding phones can
+            # silently evict Home Assistant from that table, after which polls fail
+            # until the integration is reloaded. Proactively re-register our account
+            # on failure so we recover automatically on the next poll if we were
+            # evicted. add_account() is self-contained and swallows its own errors.
+            await self.add_account()
             return
 
         try:
@@ -212,7 +219,11 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
     async def _async_update_data(self):
         """Update data via library."""
         try:
-            async with timeout(10):
+            # Match the underlying HTTP request timeout (30s). The WF-RAC adapter
+            # is slow/flaky and frequently answers in 10-20s; a tighter coordinator
+            # timeout here would cancel slow-but-valid polls and mark the entity
+            # unavailable even though the unit was about to respond.
+            async with timeout(30):
                 await asyncio.gather(*[self.update()])
         except Exception as error:
             raise UpdateFailed(error) from error

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -72,10 +72,11 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
                 self._set_availability(False)
                 _LOGGER.warning("Received no data for device %s", self._airco_id)
                 return
-        except Exception:  # pylint: disable=broad-except
+        except Exception as e:  # pylint: disable=broad-except
             self._set_availability(False)
             _LOGGER.warning(
-                "Error: something went wrong updating the airco [%s] values", self.device_name
+                "Error: something went wrong updating the airco [%s] values", self.device_name,
+                exc_info=e,
             )
             # The WF-RAC module keeps only a small, fixed-size table of registered
             # accounts (operator ids). Opening the official app or adding phones can


### PR DESCRIPTION
## Summary

Combines two already-open, non-conflicting fixes for the "AC climate entity goes `unavailable`
intermittently" reports, credited fully to their original authors, plus two small follow-on fixes
found while live-testing the combination against three real production WF-RAC units over several
hours. This PR is not a competing implementation — it's #193 + #200 stacked as-is, verified, and
extended slightly based on what the verification turned up.

**All credit for the core fix goes to @spiri439 (#193) and @blues-sechseck (#200).** This PR exists
to combine their work (they touch different files and don't conflict) and to attach reproducible,
real-hardware evidence that the combination actually fixes the reported behavior.

## What's included

1. **#193 by @spiri439** — [Fix intermittent disconnects (poll timeout + account re-registration)](https://github.com/jeatheak/Mitsubishi-WF-RAC-Integration/pull/193), cherry-picked unmodified.
2. **#200 by @blues-sechseck** — [Fix availability_retry option key mismatch](https://github.com/jeatheak/Mitsubishi-WF-RAC-Integration/pull/200), cherry-picked unmodified.
3. **New:** log the real exception in the poll-failure path (`exc_info=e`) — it was being discarded, which made it impossible to tell from the log alone which failure mode was firing. This is what let the live test below produce real tracebacks instead of one-line messages.
4. **New:** fix a silent command-send failure discovered during live testing (details below) — a different, previously-unprotected code path hitting the same underlying root cause.

## Root cause (independently confirmed)

Each unit's WF-RAC module cycles its own Wi-Fi radio on an independent, roughly-hourly firmware
watchdog — not network flakiness, not a config issue. Confirmed two ways:

- **HA logs**: on one of the three test units, poll failures landed within seconds of the same clock
  offset, hour after hour, across separate days (`00:04:07` → `01:04:07` → `02:04:09` ...).
- **UniFi**: all three units' MACs resolve to the BroadLink OEM radio the WF-RAC module actually uses,
  with live reassociation activity on their own independent schedules. The unit with the highest
  failure rate (77 blips/week vs. 27-32 for its identical siblings) was also the one on the weakest
  AP link — consistent with the same firmware behavior, just a wider overlap window with HA's poll.

This is a hardware/firmware behavior being worked around in software, which is exactly what #193 and
#200 do.

## Why combine #193 and #200 rather than land separately

They're complementary, not redundant:
- Nearly all observed failures are single, isolated poll failures — well within the 3-poll tolerance
  #200's fix unlocks. #200 alone would likely mask most of what's reported.
- #193's timeout fix protects the cases where the response is slow-but-valid (10-29s) rather than an
  outright connection error, so the coordinator doesn't cancel it prematurely.
- #193's account re-registration is a defensive backstop against a separate, rarer failure mode
  (account-table eviction) not directly exercised in this test but plausible per the module's known
  behavior (small fixed-size account table).

## Additional fix #1 — exception logging

`wfrac/device.py`'s connectivity-failure except-block logged only a generic
`"Error: something went wrong updating the airco [%s] values"` with no `exc_info`, unlike the
parse-failure except-block right below it which already does this correctly. One-line fix,
`exc_info=e`, matching the existing pattern.

## Additional fix #2 — silent command-send failure

Found live during testing: a real command to one of the units (a temperature/mode change via the
"consolidate rapid slider changes into one delayed send" pattern in `climate.py`) hit a hard
connection error mid-flight:

```
Could not send airco data: Aircon returned error: Cannot connect to host ...:51443 ssl:default [Connect call failed (...)]
...
ERROR [homeassistant] Error doing job: Task exception was never retrieved (task: None)
```

`climate.py`'s `_set_airco_after_delay()` runs as a **detached task**
(`hass.async_create_task(...)`, nothing ever awaits it) and calls `Device.set_airco()` — which
deliberately logs and **re-raises** on failure — with no try/except around it. With nothing to catch
the re-raised exception, it becomes an orphaned task exception: logged once by asyncio's own default
handler, with **zero feedback anywhere in the HA UI** that the user's command never reached the unit.
Same root cause (device unreachable mid reconnect-cycle) hitting a second, previously-unprotected
code path. Fixed by wrapping the call and still refreshing entity state afterward so it picks up
`self._device.available` if the same failure already flipped it there.

## Live test evidence

Tested against three real production units (`Airco Kantoor`, `Airco Huiskamer`, `Airco Overloop`) on
HA 2026.7.3, integration 2025.12. Full write-up with timestamps, raw log excerpts, and UniFi data below.

**Key result:** with the combined fix deployed but `availability_check` not yet enabled anywhere
(pre-existing state — nobody had opted in via the Options Flow), a genuine failure on Kantoor still
flipped it `unavailable` immediately (control case, expected). After enabling
`availability_check`/`availability_retry_limit=3` via the Options Flow, a second genuine failure with
an identical signature hit Kantoor — and the entity's state history showed **zero transitions**. It
never went unavailable. Direct, reproducible confirmation that #200's retry-tolerance — once actually
enabled — works as intended, on real hardware, live.

A third, structurally different failure (a genuine coordinator-level timeout on a different unit,
bypassing the per-poll handling entirely) also produced zero visible impact, for reasons detailed in
the full write-up — worth a read for anyone auditing the availability logic further.

<details>
<summary>Full findings, raw log excerpts, and UniFi network correlation</summary>

# WF-RAC intermittent-disconnect fix: root-cause confirmation and live test

Investigation of upstream PRs [#193](https://github.com/jeatheak/Mitsubishi-WF-RAC-Integration/pull/193)
and [#200](https://github.com/jeatheak/Mitsubishi-WF-RAC-Integration/pull/200) against three real
production WF-RAC units (my own household units, named for the room each one serves), running on Home Assistant
2026.7.3, integration version 2025.12 (`installed_commit: 5ebb995`).

**Verdict: confirmed hardware/firmware behavior, correctly worked around in software. Both PRs are
implemented as described, are complementary, and a live test of the combined fix (+ two additional
patches found along the way) confirms the retry-tolerance path actually prevents the failure from
surfacing as `unavailable` — and turned up one more real, separate bug in the process (silent
command-send failures).**

## 1. Root-cause confirmation

### 1.1 HA state-history baseline (7 days pre-fix, all 3 units)

| Entity | `unavailable` transitions in 7 days | Typical outage duration |
|---|---|---|
| `climate.airco_overloop` | 32 | 30–90s |
| `climate.airco_huiskamer` | 27 | 30–90s |
| `climate.airco_kantoor` | 77 | 30–90s (one ~60min outlier) |

All three show frequent, short `unavailable` blips that self-recover within one or two poll cycles —
the pattern PR #193 describes, not a persistent connectivity loss.

### 1.2 HA log — the smoking gun (Kantoor)

```
2026-07-22 00:04:07  Error: something went wrong updating the airco [Airco Kantoor] values
2026-07-22 01:04:07  Error: ...                                          (60:00 later)
2026-07-22 02:04:09  Error: ...                                          (60:02 later)
2026-07-22 04:05:08  Error: ...
2026-07-23 00:04:59  Error: ...
2026-07-23 01:05:03  Error: ...                                          (60:04 later)
2026-07-23 02:05:03  Error: ...                                          (60:00 later)
```

Failures land within seconds of the same offset, hour after hour, across two separate days. This is
a device-side periodic watchdog cycle, not random Wi-Fi noise — independently corroborating the
theory from PR #193's confirming comment
([blues-sechseck](https://github.com/jeatheak/Mitsubishi-WF-RAC-Integration/pull/193#issuecomment-5051391917)):
each unit's Wi-Fi radio disconnects/reconnects on its own stable ~60-minute firmware
keepalive/watchdog cycle.

Also present throughout the log: repeated `Update of climate.airco_kantoor is taking over 10
seconds` — HA core's own slow-callback warning, independently confirming polls to this unit
routinely exceed 10s, the exact premise PR #193's timeout fix rests on.

### 1.3 UniFi corroboration

All three device MACs resolve to OUI `Hangzhou BroadLink Technology Co.,Ltd` — the OEM Wi-Fi radio
used inside the WF-RAC module — confirming these are the actual AC units, not look-alikes. Live
`stat/user` data showed recent `assoc_time`/`disconnect_timestamp` activity consistent with ongoing
reconnect cycling.

Notably, **Kantoor associates via a `U6 Extender` mesh uplink**, while Huiskamer and Overloop both
use `AP zolder` directly. Kantoor also showed far more link-layer retries (2513 vs 217) and a weaker
signal than Overloop. This plausibly explains why Kantoor (77 blips/week) fails far more often than
the other two identical units (27–32/week): same firmware bug, worse RF path widens the overlap
window between the device's reconnect cycle and HA's poll. This is an environmental factor, not a
code issue — flagged here as a secondary, non-blocking observation.

(Could not pull a historical per-event UniFi log — the legacy `stat/event`/`stat/alarm` REST
endpoints return 404 on this controller version, and no equivalent v2 event-history endpoint was
found. The HA-log correlation above is the primary evidence and is unambiguous on its own.)

## 2. Code review

Both PRs were diffed against current `main` (`5ebb995`) and read in full, not just their
descriptions.

### PR #193 — `wfrac/device.py`

Confirmed exactly as described:
- `repository.py`'s `_post()` uses `aiohttp.ClientTimeout(total=30)` for the real HTTP request.
- `device.py`'s `_async_update_data()` wrapped the whole poll in `async_timeout.timeout(10)` — a
  tighter, independent timeout that cancels a legitimately slow-but-valid 10-29s response before the
  real HTTP layer would ever time out. PR #193 raises this to `30` to match.
- Adds `await self.add_account()` in the connectivity-failure except-block of `update()` (not the
  response-parsing except-block) — correctly scoped, since account-table eviction would surface as a
  connectivity failure, not a parse failure. `add_account()` is fire-and-forget and swallows its own
  errors, so it can't introduce a new failure mode.

### PR #200 — `__init__.py`

Confirmed byte-for-byte:
- `create_device_from_entry()` read the literal string `"availability_retry"` as the options key.
- That key is **only ever written by the entry-migration code itself** (`__init__.py`
  `async_migrate_entry`, `new_options["availability_retry"] = False`) — a permanently dead default,
  never touched again.
- The real Options Flow (`config_flow.py`) writes `CONF_AVAILABILITY_CHECK` (`"availability_check"`)
  instead. So the retry-tolerance logic in `Device._set_availability()` — gated by
  `_availability_retry_limit` — was silently disabled for every user regardless of what they
  configured.
- Fix: read `CONF_AVAILABILITY_CHECK` instead. One line, correct.

### Complementarity

The two fixes cover different failure shapes and reinforce each other:
- Nearly all observed failures are single, isolated poll failures (one hourly blip, not several in a
  row) — well within the 3-poll tolerance PR #200 unlocks. PR #200 alone would likely mask most of
  what's observed here.
- PR #193's timeout fix protects the cases where the response is slow-but-valid (10-29s) rather than
  an outright connection error, so the coordinator doesn't kill it prematurely.
- PR #193's account re-registration is a defensive backstop against a different, rarer failure mode
  (account-table eviction from opening the official app) not directly exercised in this test window.

### Gap #1 found and fixed — silent exception in the poll-failure log

`device.py`'s connectivity-failure except-block logged only a generic
`"Error: something went wrong updating the airco [%s] values"` with no `exc_info` — discarding the
actual exception (timeout vs connection error vs HTTP error), unlike the parse-failure except-block
right below it which already does this correctly. Added `exc_info=e` to match, as its own commit on
top of the two PRs. This is what let the live test below actually show the real exception
(`AirconApiError` with full traceback) instead of a bare one-line message.

### Gap #2 found and fixed — silent failure on command send

While monitoring, a real command to Airco Huiskamer (a temperature/mode change via the
"consolidate rapid slider changes into one delayed send" pattern) hit a hard connection error
mid-flight. Tracing it: `climate.py`'s `_set_airco_after_delay()` runs as a **detached task**
(`hass.async_create_task(...)`, nothing ever awaits it) and calls `Device.set_airco()` with no
try/except. `set_airco()` deliberately logs and **re-raises** on failure — so when nothing catches
that re-raised exception, it becomes an orphaned task exception, logged once by asyncio's own default
handler (`Task exception was never retrieved`) with **zero feedback anywhere in the HA UI** that the
user's command never reached the unit. This is the same root cause (device unreachable mid
reconnect-cycle) hitting a second, previously unprotected code path — not something either #193 or
#200 touches, since both are scoped to polling/availability, not command-sending.

Fix: wrap the call in `try/except`, keep it silent-but-safe (the underlying error is already logged
by `set_airco()`), and still run `_update_state()`/`async_write_ha_state()` afterward so the entity
picks up `self._device.available` if the same failure already flipped it there.

## 3. Test branch

```
main (5ebb995)
 └─ test/193-plus-200
     ├─ 54a5d9f  Fix intermittent disconnects (timeout + account re-registration)     [PR #193, unmodified]
     ├─ 1222363  Fix availability_retry option key mismatch     [cherry-picked from PR #200, orig 7c7a277]
     ├─ 761dbc8  Log the real exception for airco update failures                     [new, this session]
     └─ 671609d  Prevent orphaned task exception on failed delayed airco command      [new, this session]
```

Branched from `spiri439/pr/intermittent-disconnects`, cherry-picked
`blues-sechseck/fix/availability-retry-option-key` (clean, no conflicts), then added the exc_info
commit and the command-send fix, each in response to evidence surfaced during the live test below.

## 4. Deploy procedure used

1. Backed up the live HACS-installed copy on ct100:
   `custom_components/mitsubishi_wf_rac.bak-20260723_093524`
2. Deployed `test/193-plus-200` via `tar` pipe through `pve` → `pct exec 100`.
3. Restarted HA via `POST /api/services/homeassistant/restart` — came back clean at 07:37 UTC, all
   three climate entities available, only the standard "untested custom integration" warning in the
   log (no import errors).
4. Verified all three fixes present in the deployed files (`exc_info=e`, `timeout(30)`,
   `CONF_AVAILABILITY_CHECK, False`).

## 5. Live test results

### Phase 1 — fix deployed, `availability_check` not yet enabled (07:37–08:07 UTC)

None of the three config entries had ever had "Availability Check" turned on in their Options Flow —
only the dead `availability_retry: False` key from the old migration was present. So even with
PR #200's code fix deployed, the retry-tolerance path was still dormant (correctly defaulting to
`False` since the real key was simply absent, not a residual bug).

At **08:05:41 UTC**, Kantoor hit a genuine connectivity failure:

```
2026-07-23 10:05:41.070 WARNING [custom_components.mitsubishi_wf_rac.wfrac.device] Error: something went wrong updating the airco [Airco Kantoor] values
  File ".../wfrac/repository.py", line 66, in _execute_request
  File ".../wfrac/device.py", line 69, in update
  File ".../wfrac/repository.py", line 185, in get_aircon_stats
  File ".../wfrac/repository.py", line 132, in _post
  File ".../wfrac/repository.py", line 108, in _execute_request
custom_components.mitsubishi_wf_rac.wfrac.repository.AirconApiError: Aircon returned error:
```

The exc_info fix gave a full traceback for the first time — showing this was a genuine
connection-level `AirconApiError` (fails fast in `_execute_request`), not a slow-response case that
the 30s timeout bump would have caught. The entity went `unavailable` immediately (single failure,
no retry-tolerance active yet) — expected given the config state, not a fix failure.

**Decision point:** since none of the three units had this option enabled, the combined fix's most
important behavior (masking isolated blips) was untested. Enabled `availability_check: true`,
`availability_retry_limit: 3` on all three via HA's Options Flow API
(`/api/config/config_entries/options/flow`). The integration's existing
`entry.add_update_listener(async_update_options)` auto-reloaded each entry — confirmed via
`core.config_entries` storage and by re-checking entity states, no manual restart needed.

This reload caused a simultaneous, near-instant `unavailable`/`off` flicker across all three
entities at 08:07:49-08:07:50 UTC — a testing artifact from tearing down/recreating the three
coordinators, not a recurrence of the underlying bug. Documented here so it isn't mistaken for one.

### Phase 2 — retry-tolerance active (08:08 UTC onward)

At **08:53:21 UTC** (~48 min after the previous failure — same clockwork pattern, not exactly 60min
but same order of magnitude), Kantoor hit another genuine `AirconApiError`, identical signature to
the one above:

```
2026-07-23 10:53:00.416 WARNING [homeassistant.helpers.entity] Update of climate.airco_kantoor is taking over 10 seconds
2026-07-23 10:53:21.072 WARNING [custom_components.mitsubishi_wf_rac.wfrac.device] Error: something went wrong updating the airco [Airco Kantoor] values
  ... (same traceback as above) ...
custom_components.mitsubishi_wf_rac.wfrac.repository.AirconApiError: Aircon returned error:
2026-07-23 10:53:50.417 WARNING [homeassistant.components.climate] Updating mitsubishi_wf_rac climate took longer than the scheduled update interval 0:01:00
2026-07-23 10:53:52.071 WARNING [custom_components.mitsubishi_wf_rac.wfrac.device] Could not add account from airco e81656040872
```

The last line confirms PR #193's re-registration path fired as designed (and itself failed
silently, as expected, since the device was still unreachable at that exact instant — swallowed by
its own except-block without side effects).

**Critically: `climate.airco_kantoor`'s state history shows zero transitions since the 08:07:50
reload, through this failure, to the time of writing.** The entity never flipped to `unavailable`.
This is direct, reproducible proof that PR #200's retry-tolerance — once actually enabled — masks
exactly the failure mode this whole investigation is about, on real hardware, in real time.

Huiskamer and Overloop showed no failures of their own in this window (Kantoor's weaker AP link
means it's still the highest-signal test unit).

### Phase 3 — a second, different failure mechanism (Overloop, 10:35:36 UTC)

```
2026-07-23 12:35:36.114 ERROR [custom_components.mitsubishi_wf_rac.wfrac.device] Error fetching Airco Overloop data:
```

Different signature from the Kantoor failures above — this is HA core's own `DataUpdateCoordinator`
error log (`update_coordinator.py:468`, `self.logger.error("Error fetching %s data: %s", ...)`),
using the logger instance `Device.__init__` passes into the coordinator base class. It only fires
when `_async_update_data()` itself raises `UpdateFailed`, a level above `update()`'s own try/except —
meaning this failure bypassed the graceful per-poll handling (`_set_availability(False)`,
`add_account()`) entirely, most likely because a genuine `async_timeout.timeout(30)` expiry cancels
the in-flight call via `CancelledError`, which — being a `BaseException`, not an `Exception` — skips
past `update()`'s `except Exception:` block untouched, and only turns into a catchable `TimeoutError`
once `async_timeout`'s context manager exits at the `_async_update_data` boundary.

Checked Overloop's state history through and after this event: zero transitions, not even a brief
flicker. `Device._available` was simply never touched by this failure path, so it kept its last
known value. Net effect: no user-visible impact, same as the masked Kantoor case, but via a
structurally different route. Noting this as an open architectural observation rather than a proven
bug: `AircoClimate` (`climate.py`) is a plain `ClimateEntity`, not a `CoordinatorEntity` — it has its
own independent `async_update()` that also calls `self._device.update()` and has its own
except-block that could set `_attr_available = False` directly, bypassing `_set_availability()`'s
retry counting if it ever fires. Not confirmed to have triggered here; flagged for anyone digging
further upstream, not claimed as fact.

### Phase 4 — command-send fix deployed, restart at 11:53 UTC

Deployed the `_set_airco_after_delay()` fix (Gap #2 above), restarted HA — clean, all three entities
available immediately after. As of this writing (13:43 UTC, ~1h50m post-restart): zero wfrac log
activity of any kind, zero `unavailable` transitions. No command has been sent to any unit during a
bad window since the fix landed, so it hasn't been directly re-exercised yet — the fix is justified
by tracing the exact failure mechanism (confirmed via the `Task exception was never retrieved` log
line), not yet by a second live reproduction.

## 6. Conclusion

- The intermittent-unavailable issue is confirmed to be a genuine hardware/firmware behavior (a
  per-unit, independently-clocked Wi-Fi watchdog/reconnect cycle, roughly hourly) rather than network
  or configuration flakiness on Michael's side.
- PR #193 and PR #200 are both correctly implemented and directly target this confirmed root cause;
  they are complementary rather than redundant.
- Live-tested on real hardware: with both fixes plus the `availability_check` option actually
  enabled, a genuine device-side failure that would previously have caused an immediate
  `unavailable` flip was fully masked.
- One small additional fix (`exc_info` logging) is worth carrying in the same PR — it's what made
  this test's evidence legible in the first place, and costs nothing.
- A second, independent bug was found during testing: outgoing AC commands can silently fail with
  zero HA-visible feedback when a unit is unreachable mid-cycle (an orphaned detached-task exception
  in `climate.py`). Same root cause, different code path, not covered by either PR — fixed alongside
  them.
- Recommendation to file upstream: land #193 + #200 together, and consider defaulting
  `availability_check` to discoverable/on by default in the config flow (it already defaults to
  `True` in the *options form*, but that default is never persisted unless the user opens the options
  dialog and submits it — as seen here, all three of my entries had it silently absent).

</details>

## Test plan

- [x] Applied combined fix to a HACS-managed production install (not a dev environment)
- [x] Backed up the pre-existing installed copy before deploying
- [x] Confirmed all three climate entities remained functional through two full restart cycles
- [x] Confirmed retry-tolerance masks a real failure once `availability_check` is enabled (see above)
- [x] Confirmed the exc_info fix surfaces real tracebacks in place of generic one-liners
- [ ] Confirmed the command-send fix directly (traced via the exact failure mechanism and asyncio's
      own orphaned-task log; a second live command failure during a bad window would confirm it
      empirically, not yet observed post-fix)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
