### PR TITLE
Fix async_add_executor_job misuse in Device.set_airco()

### DIFF
--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -109,7 +109,11 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         """Method to send airco command"""
         _LOGGER.debug("Setting airco: %s", params)
         if self.airco is None:
-            await self._hass.async_add_executor_job(self.update)
+            # update() is a coroutine function; async_add_executor_job is for
+            # blocking sync calls and would not actually run it (no event loop
+            # in the executor thread), so the coroutine was silently never
+            # awaited. Await it directly instead.
+            await self.update()
 
         if self._airco is None:
             raise ValueError("Airco object is empty")


### PR DESCRIPTION
\`set_airco()\` passed the coroutine function \`self.update\` to \`async_add_executor_job\`, which runs targets in a worker thread with no event loop — the coroutine was created but never awaited. Fixed to \`await self.update()\` directly.

Note: \`self._airco\` is never \`None\` after \`__init__\`, so this branch is currently unreachable — a latent bug, not an active one. Fixing for correctness.