### PR TITLE
Core-readiness cleanup: exceptions, ConfigEntryNotReady, dead code

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -5,6 +5,7 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from homeassistant.const import (
     CONF_HOST,
@@ -18,7 +19,7 @@ from .const import (
     CONF_AIRCO_ID,
     CONF_AVAILABILITY_CHECK,
     CONF_AVAILABILITY_RETRY_LIMIT,
-    CONF_OPERATOR_ID, CONF_CREATE_SWING_MODE_SELECT, DOMAIN
+    CONF_OPERATOR_ID, CONF_CREATE_SWING_MODE_SELECT,
 )
 from .wfrac.device import Device
 
@@ -63,28 +64,27 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEntry) -> bool:
     """Establish connection with mitsubishi-wf-rac."""
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {}
-    hass.data[DOMAIN][entry.entry_id]["devices"] = coordinators = []
-
     device: str = entry.options[CONF_HOST]
     _device = await create_device_from_entry(entry, hass)
 
-    coordinators.append(_device)
-    try:
-        await _device.update()  # initial update to get fresh values
-        entry.runtime_data = MitsubishiWfRacData(_device)
-        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-        entry.async_on_unload(entry.add_update_listener(async_update_options))
-    except Exception as ex:  # pylint: disable=broad-except
-        _LOGGER.warning("Something whent wrong setting up device [%s] %s", device, ex)
+    await _device.update()  # initial update to get fresh values
+    # update() catches its own errors and reflects them via .available instead
+    # of raising (see wfrac/device.py) - check that instead of try/except so a
+    # device that's unreachable at startup gets HA's automatic retry-with-backoff
+    # rather than a silently "loaded" entry with no working entities.
+    if not _device.available:
+        raise ConfigEntryNotReady(f"Could not reach device [{device}]")
+
+    entry.runtime_data = MitsubishiWfRacData(_device)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
 
     return True
 
 
-async def create_device_from_entry(entry, hass):
+async def create_device_from_entry(entry: ConfigEntry, hass: HomeAssistant) -> Device:
     device: str = entry.options[CONF_HOST]
     name: str = entry.data[CONF_NAME]
     device_id: str = entry.data[CONF_DEVICE_ID]
@@ -123,20 +123,24 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
         _LOGGER.warning("Failed to update options to [%s]", entry.options)
 
 
-async def async_remove_entry(hass, entry: MitsubishiWfRacConfigEntry) -> None:
+async def async_remove_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEntry) -> None:
     """Handle removal of an entry."""
 
     temp_device = await create_device_from_entry(entry, hass)
-    try:
-        await temp_device.delete_account()
+    # delete_account() catches its own errors and returns None on failure (see
+    # wfrac/device.py) rather than raising, so check the result instead of
+    # try/except - the previous try/except here could never actually trigger,
+    # and the "Deleted" log below used to fire unconditionally even on failure.
+    result = await temp_device.delete_account()
+    if result is not None:
         _LOGGER.info(
             "Deleted operator ID [%s] from airco [%s]",
             temp_device.operator_id,
             temp_device.airco_id,
         )
-    except Exception as ex:  # pylint: disable=broad-except
+    else:
         _LOGGER.warning(
-            "Something whent wrong deleting account from airco [%s] %s",
-            temp_device.device_name,
-            ex,
+            "Could not delete operator ID [%s] from airco [%s]",
+            temp_device.operator_id,
+            temp_device.airco_id,
         )

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -291,7 +291,7 @@ class AircoClimate(ClimateEntity):
         try:
             await self._device.update()
             self._update_state()
-        except Exception:  # pylint: disable=broad-except
+        except (IndexError, KeyError, AttributeError, ValueError):
             _LOGGER.warning("Could not update the airco values")
             self._attr_available = False
             self._device.set_available(False)

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -30,7 +30,7 @@ from .const import (
     CONF_OPERATOR_ID,
     DOMAIN,
 )
-from .wfrac.repository import Repository
+from .wfrac.repository import AirconApiError, Repository
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -93,7 +93,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             airco_id = await repository.get_airco_id()
-        except Exception as query_failed:
+        except (AirconApiError, KeyError, TypeError) as query_failed:
             raise CannotConnect(reason=str(query_failed)) from query_failed  # type: ignore
 
         data[CONF_AIRCO_ID] = airco_id
@@ -167,7 +167,10 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     else:
                         description_placeholders[key] = value
             except Exception:  # pylint: disable=broad-except
-                _LOGGER.error("Unexpected exception")
+                # Intentionally broad: this is the outermost boundary of the config
+                # flow step, so any bug here should show the user a graceful
+                # "unexpected_error" instead of crashing the flow.
+                _LOGGER.error("Unexpected exception", exc_info=True)
                 errors[CONF_BASE] = "unexpected_error"
 
         # If there is no user input or there were errors, show the form again, including any errors

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -8,13 +8,12 @@ from async_timeout import timeout
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import Throttle
 
 from .rac_parser import RacParser
-from .repository import Repository
+from .repository import AirconApiError, Repository
 from .models.aircon import Aircon, AirconStat
 
-from ..const import DOMAIN, MIN_TIME_BETWEEN_UPDATES
+from ..const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,9 +60,17 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             update_interval=timedelta(seconds=60),
         )
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def update(self):
-        """Update the device information from API"""
+        """Update the device information from API.
+
+        Called both directly (e.g. by entities' own async_update()) and by
+        the coordinator via _async_update_data() below. Does not call
+        async_refresh()/async_set_updated_data() - no entity in this
+        integration is a CoordinatorEntity/listener, so there's nothing to
+        notify, and calling async_refresh() here would re-enter
+        _async_update_data() -> update() from within the coordinator-driven
+        path.
+        """
 
         try:
             response = await self._api.get_aircon_stats()
@@ -72,10 +79,12 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
                 self._set_availability(False)
                 _LOGGER.warning("Received no data for device %s", self._airco_id)
                 return
-        except Exception:  # pylint: disable=broad-except
+        except (AirconApiError, KeyError) as ex:
             self._set_availability(False)
             _LOGGER.warning(
-                "Error: something went wrong updating the airco [%s] values", self.device_name
+                "Error: something went wrong updating the airco [%s] values",
+                self.device_name,
+                exc_info=ex,
             )
             return
 
@@ -83,18 +92,18 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             self._connected_accounts = int(response["numOfAccount"])
             self._firmware = f'{response["firmType"]}, mcu: {response["mcu"]["firmVer"]}, wireless: {response["wireless"]["firmVer"]}'
             self._airco = self._parser.translate_bytes(response["airconStat"])
-            await self.async_refresh()
             self._set_availability(True)
-        except Exception as e:  # pylint: disable=broad-except
-            _LOGGER.warning("Could not parse airco data", exc_info=e)
+        except (KeyError, TypeError, ValueError) as ex:
+            _LOGGER.warning("Could not parse airco data", exc_info=ex)
             self._set_availability(False)
 
     async def delete_account(self):
         """Delete account (operator id) from the airco"""
         try:
             return await self._api.del_account_info(self._airco_id)
-        except Exception:  # pylint: disable=broad-except
+        except (AirconApiError, KeyError, TypeError):
             _LOGGER.warning("Could not delete account from airco %s", self._airco_id)
+            return None
 
     async def add_account(self):
         """Add account (operator id) from the airco"""
@@ -102,14 +111,15 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             return await self._api.update_account_info(
                 self._airco_id, self._hass.config.time_zone
             )
-        except Exception:  # pylint: disable=broad-except
+        except (AirconApiError, KeyError, TypeError):
             _LOGGER.warning("Could not add account from airco %s", self._airco_id)
+            return None
 
     async def set_airco(self, params: dict[str, Any]) -> None:
         """Method to send airco command"""
         _LOGGER.debug("Setting airco: %s", params)
         if self.airco is None:
-            await self._hass.async_add_executor_job(self.update)
+            await self.update()
 
         if self._airco is None:
             raise ValueError("Airco object is empty")
@@ -123,9 +133,8 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             command = self._parser.to_base64(airco_stat)
             response = await self._api.send_airco_command(self._airco_id, command)
             self._airco = self._parser.translate_bytes(response)
-            await self.async_refresh()
-        except Exception as e:  # pylint: disable=broad-except
-            _LOGGER.warning("Could not send airco data: %s", str(e))
+        except (AirconApiError, KeyError, TypeError, ValueError) as ex:
+            _LOGGER.warning("Could not send airco data: %s", str(ex))
             raise
 
     def _set_availability(self, available: bool):


### PR DESCRIPTION
A few correctness/cleanup fixes found while reviewing for Core/HACS-default readiness:

- \`async_setup_entry\` now raises \`ConfigEntryNotReady\` on an unreachable device at startup instead of silently loading a broken entry.
- Removed a re-entrant \`update() → async_refresh() → update()\` loop in \`Device\` (harmless today only because the now-removed \`@Throttle\` no-op'd the inner call). No entity here listens to the coordinator, so nothing was actually being notified.
- Narrowed \`except Exception\` to specific types at each call site where the failure modes are known; kept broad catches only where that's the right pattern (config flow's outer boundary, the parser's encode/decode, the coordinator's \`UpdateFailed\` translation).
- \`async_remove_entry\`'s try/except around \`delete_account()\` could never trigger and the success log fired unconditionally even on failure — fixed to check the return value.
- Removed unused \`hass.data[DOMAIN]\` bookkeeping (superseded by \`entry.runtime_data\`), fixed two log typos.

No behavior change on the happy path.