### PR TITLE
Fix reset-energy button marking device unavailable on every poll

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,6 @@ Configurable via the integration's "Configure" (options) flow.
 | Option | Range | Description |
 |---|---|---|
 | Host (IP) address | IP or hostname | Address of the WF-RAC module. |
-| Check availability | on/off, on by default | Whether a failed poll is tolerated before the device is marked unavailable. Off marks it unavailable on the first failed poll. |
-| Retry limit | 2 or higher, default 3 | Consecutive failed polls before the device is marked unavailable. At the 60 s poll interval, `3` is about 3 minutes. `0` and `1` mark it unavailable on the first failed poll, identical to Check availability being off. |
 | Indoor Temp. Sensor Offset | -15..15 °C | Added to the unit's own indoor-sensor reading before it's shown as `current_temperature` / the Indoor Temperature sensor - display-only, doesn't change what the unit does. |
 | Outdoor Temp. Sensor Offset | -15..15 °C | Same, for the Outdoor Temperature sensor. |
 | Target Temp. Offset | -5..5 °C | Calibrates the *setpoint sent to the unit* - see "Target Temp. Offset sign convention" below. Applies to every `hvac_mode` unless overridden by the two options below. |
@@ -156,12 +154,9 @@ interface does "connect / disconnect every one hour … to avoid too much cache 
 ([source](https://community.ui.com/questions/AC-Units-IOT-disconnecting-from-UniFi-Wi-Fi-at-regular-hourly-Intervals/821cd3e4-46a0-4d6b-8fd0-8d5cf182b90f)).
 The reassociation takes seconds to about a minute and cannot be turned off.
 
-This integration polls every 60 seconds, so a reassociation can cost a poll. The availability
-options decide whether that becomes a visible outage:
-
-- **Check availability**: on (the default).
-- **Retry limit**: `3` (the default) — the device is marked unavailable after 3 consecutive failed
-  polls, about 3 minutes. `0` and `1` mark it unavailable on the first failed poll.
+This integration polls every 60 seconds, so a reassociation can cost a poll. That does not become a
+visible outage: the device is only reported unavailable after three consecutive failed polls, about
+three minutes, which rides through the reassociation. There is nothing to configure for this.
 
 ## Unit goes unavailable for about an hour
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Configurable via the integration's "Configure" (options) flow.
 | Option | Range | Description |
 |---|---|---|
 | Host (IP) address | IP or hostname | Address of the WF-RAC module. |
+| Retry limit | 3 or higher, default 3 | Consecutive failed polls before the device is marked unavailable. At the 60 s poll interval, `3` is about 3 minutes - enough to ride through the module's hourly WiFi reassociation. Raise it on a weak link; it cannot be set lower. |
 | Indoor Temp. Sensor Offset | -15..15 °C | Added to the unit's own indoor-sensor reading before it's shown as `current_temperature` / the Indoor Temperature sensor - display-only, doesn't change what the unit does. |
 | Outdoor Temp. Sensor Offset | -15..15 °C | Same, for the Outdoor Temperature sensor. |
 | Target Temp. Offset | -5..5 °C | Calibrates the *setpoint sent to the unit* - see "Target Temp. Offset sign convention" below. Applies to every `hvac_mode` unless overridden by the two options below. |
@@ -156,7 +157,8 @@ The reassociation takes seconds to about a minute and cannot be turned off.
 
 This integration polls every 60 seconds, so a reassociation can cost a poll. That does not become a
 visible outage: the device is only reported unavailable after three consecutive failed polls, about
-three minutes, which rides through the reassociation. There is nothing to configure for this.
+three minutes, which rides through the reassociation. If your link is weak enough that this still
+shows up, raise **Retry limit** in the options; three is the minimum, not a target.
 
 ## Unit goes unavailable for about an hour
 

--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -86,6 +86,18 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             new_options[CONF_AVAILABILITY_RETRY_LIMIT] = 3
 
         hass.config_entries.async_update_entry(entry, options=new_options, version=4)
+    if entry.version == 4:
+        # Drop the availability options. Neither had a defensible setting: the
+        # module's hourly reassociation makes some tolerance always right, and
+        # values below 2 were arithmetically identical to switching tolerance
+        # off. The v3 -> v4 step above already had to correct user-chosen
+        # values, which is the argument for it not being a user choice.
+        # Behaviour is now Device.AVAILABILITY_FAILURE_LIMIT.
+        new_options = dict(entry.options)
+        new_options.pop(CONF_AVAILABILITY_CHECK, None)
+        new_options.pop(CONF_AVAILABILITY_RETRY_LIMIT, None)
+
+        hass.config_entries.async_update_entry(entry, options=new_options, version=5)
 
     return True
 
@@ -130,17 +142,6 @@ async def create_device_from_entry(entry: ConfigEntry, hass: HomeAssistant) -> D
     operator_id: str = entry.data[CONF_OPERATOR_ID]
     port: int = entry.data[CONF_PORT]
     airco_id: str = entry.data[CONF_AIRCO_ID]
-    # Bugfix: config_flow.py stores this toggle under CONF_AVAILABILITY_CHECK
-    # ("availability_check") via the Options Flow; the literal "availability_retry"
-    # key is never written anywhere, so this always defaulted to False and the
-    # retry-tolerance logic in wfrac/device.py (_availability_retry_limit) was
-    # dead code even when the user enabled "Availability Check" in the UI.
-    # The default here is True to match both the value new entries are created
-    # with (config_flow._async_create_common) and the one the options form shows
-    # for a missing key - it used to be False, so an entry without the key ran
-    # with the tolerance off while the form displayed it as on.
-    availability_retry: bool = entry.options.get(CONF_AVAILABILITY_CHECK, True)
-    availability_retry_limit: int = entry.options.get(CONF_AVAILABILITY_RETRY_LIMIT, 3)
     create_swing_mode_select: bool = entry.data.get(CONF_CREATE_SWING_MODE_SELECT, True)
     # Off unless the user explicitly opted in via the options flow - this is
     # the only outbound internet call in the integration (see
@@ -151,8 +152,8 @@ async def create_device_from_entry(entry: ConfigEntry, hass: HomeAssistant) -> D
     # wfrac/device.py's _maybe_request_service_data().
     service_data_enabled: bool = entry.options.get(CONF_SERVICE_DATA, False)
     connection_method: str | None = entry.data.get(CONF_CONNECTION_METHOD)
-    _device = Device(hass, name, device, port, device_id, operator_id, airco_id, availability_retry,
-                     availability_retry_limit, create_swing_mode_select,
+    _device = Device(hass, name, device, port, device_id, operator_id, airco_id,
+                     create_swing_mode_select,
                      firmware_update_check_enabled=firmware_update_check_enabled,
                      service_data_enabled=service_data_enabled,
                      connection_method=connection_method)

--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -24,7 +24,7 @@ from .const import (
     CONF_SERVICE_DATA,
     CONF_OPERATOR_ID, CONF_CREATE_SWING_MODE_SELECT,
 )
-from .wfrac.device import Device
+from .wfrac.device import AVAILABILITY_FAILURE_LIMIT_MIN, Device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,15 +87,19 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         hass.config_entries.async_update_entry(entry, options=new_options, version=4)
     if entry.version == 4:
-        # Drop the availability options. Neither had a defensible setting: the
-        # module's hourly reassociation makes some tolerance always right, and
-        # values below 2 were arithmetically identical to switching tolerance
-        # off. The v3 -> v4 step above already had to correct user-chosen
-        # values, which is the argument for it not being a user choice.
-        # Behaviour is now Device.AVAILABILITY_FAILURE_LIMIT.
+        # Drop the on/off toggle and put a floor under the retry limit. The
+        # toggle was never a defensible choice - the module's hourly
+        # reassociation makes some tolerance always right, and switching it off
+        # was arithmetically identical to a limit of 1. Raising the limit is a
+        # real choice on a weak link, so the number stays; only values below
+        # AVAILABILITY_FAILURE_LIMIT_MIN are lifted, which is what the v3 -> v4
+        # step above was already having to do by hand.
         new_options = dict(entry.options)
         new_options.pop(CONF_AVAILABILITY_CHECK, None)
-        new_options.pop(CONF_AVAILABILITY_RETRY_LIMIT, None)
+        new_options[CONF_AVAILABILITY_RETRY_LIMIT] = max(
+            AVAILABILITY_FAILURE_LIMIT_MIN,
+            new_options.get(CONF_AVAILABILITY_RETRY_LIMIT, AVAILABILITY_FAILURE_LIMIT_MIN),
+        )
 
         hass.config_entries.async_update_entry(entry, options=new_options, version=5)
 
@@ -151,9 +155,15 @@ async def create_device_from_entry(entry: ConfigEntry, hass: HomeAssistant) -> D
     # values costs an extra write to the unit on every poll. See
     # wfrac/device.py's _maybe_request_service_data().
     service_data_enabled: bool = entry.options.get(CONF_SERVICE_DATA, False)
+    # Floored in Device itself, so an entry that predates the v4 -> v5
+    # migration can't run with less tolerance than the module needs.
+    availability_failure_limit: int = entry.options.get(
+        CONF_AVAILABILITY_RETRY_LIMIT, AVAILABILITY_FAILURE_LIMIT_MIN
+    )
     connection_method: str | None = entry.data.get(CONF_CONNECTION_METHOD)
     _device = Device(hass, name, device, port, device_id, operator_id, airco_id,
                      create_swing_mode_select,
+                     availability_failure_limit=availability_failure_limit,
                      firmware_update_check_enabled=firmware_update_check_enabled,
                      service_data_enabled=service_data_enabled,
                      connection_method=connection_method)

--- a/custom_components/mitsubishi_wf_rac/button.py
+++ b/custom_components/mitsubishi_wf_rac/button.py
@@ -53,3 +53,6 @@ class EnergyTotalResetButton(WfRacEntity, ButtonEntity):
             f"{SIGNAL_SET_ENERGY_TOTAL}_{self._device.airco_id}",
             0.0,
         )
+
+    def _update_state(self) -> None:
+        """No state to reflect - the button has none."""

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -24,8 +24,6 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import (
     CONF_AIRCO_ID,
-    CONF_AVAILABILITY_CHECK,
-    CONF_AVAILABILITY_RETRY_LIMIT,
     CONF_CREATE_SWING_MODE_SELECT,
     CONF_FIRMWARE_UPDATE_CHECK,
     CONF_OPERATOR_ID,
@@ -45,7 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
-    VERSION = 4
+    VERSION = 5
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
     _discovery_info = {}
     DOMAIN = DOMAIN
@@ -156,8 +154,6 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data_input = user_input.copy()
                 options_input = {
                     CONF_HOST: user_input[CONF_HOST],
-                    CONF_AVAILABILITY_CHECK: True,
-                    CONF_AVAILABILITY_RETRY_LIMIT: 3,
                     CONF_FIRMWARE_UPDATE_CHECK: False,
                     # Off by default: each poll would otherwise carry an
                     # extra write to the unit just to piggy-back a read
@@ -333,14 +329,6 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_HOST,
                         default=self.config_entry.options.get(CONF_HOST),  # type: ignore
                     ): str,
-                    vol.Required(
-                        CONF_AVAILABILITY_CHECK,
-                        default=self.config_entry.options.get(CONF_AVAILABILITY_CHECK, True),  # type: ignore
-                    ): bool,
-                    vol.Optional(
-                        CONF_AVAILABILITY_RETRY_LIMIT,
-                        default=self.config_entry.options.get(CONF_AVAILABILITY_RETRY_LIMIT, 3),  # type: ignore
-                    ): int,
                     vol.Required(
                         CONF_FIRMWARE_UPDATE_CHECK,
                         default=self.config_entry.options.get(CONF_FIRMWARE_UPDATE_CHECK, False),  # type: ignore

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import (
     CONF_AIRCO_ID,
+    CONF_AVAILABILITY_RETRY_LIMIT,
     CONF_CREATE_SWING_MODE_SELECT,
     CONF_FIRMWARE_UPDATE_CHECK,
     CONF_OPERATOR_ID,
@@ -35,6 +36,7 @@ from .const import (
     CONF_TARGET_OFFSET_HEAT,
     DOMAIN,
 )
+from .wfrac.device import AVAILABILITY_FAILURE_LIMIT_MIN
 from .wfrac.repository import AirconApiError, Repository
 
 _LOGGER = logging.getLogger(__name__)
@@ -154,6 +156,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data_input = user_input.copy()
                 options_input = {
                     CONF_HOST: user_input[CONF_HOST],
+                    CONF_AVAILABILITY_RETRY_LIMIT: AVAILABILITY_FAILURE_LIMIT_MIN,
                     CONF_FIRMWARE_UPDATE_CHECK: False,
                     # Off by default: each poll would otherwise carry an
                     # extra write to the unit just to piggy-back a read
@@ -329,6 +332,15 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_HOST,
                         default=self.config_entry.options.get(CONF_HOST),  # type: ignore
                     ): str,
+                    # Floor, not a free number: values below the minimum were
+                    # the reason this option kept needing correcting in
+                    # migrations. Raising it stays available for weak links.
+                    vol.Required(
+                        CONF_AVAILABILITY_RETRY_LIMIT,
+                        default=self.config_entry.options.get(  # type: ignore
+                            CONF_AVAILABILITY_RETRY_LIMIT, AVAILABILITY_FAILURE_LIMIT_MIN
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=AVAILABILITY_FAILURE_LIMIT_MIN)),
                     vol.Required(
                         CONF_FIRMWARE_UPDATE_CHECK,
                         default=self.config_entry.options.get(CONF_FIRMWARE_UPDATE_CHECK, False),  # type: ignore

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -18,6 +18,8 @@ MIN_TIME_BETWEEN_UPDATES=timedelta(seconds=60)
 
 CONF_OPERATOR_ID = "operator_id"
 CONF_AIRCO_ID = "airco_id"
+# Removed options, kept only so async_migrate_entry can strip them from
+# entries that predate v5. Nothing outside the migration reads these.
 CONF_AVAILABILITY_CHECK = "availability_check"
 CONF_AVAILABILITY_RETRY_LIMIT = "availability_retry_limit"
 # Gates all outbound internet traffic (as opposed to local-network device

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -18,9 +18,11 @@ MIN_TIME_BETWEEN_UPDATES=timedelta(seconds=60)
 
 CONF_OPERATOR_ID = "operator_id"
 CONF_AIRCO_ID = "airco_id"
-# Removed options, kept only so async_migrate_entry can strip them from
-# entries that predate v5. Nothing outside the migration reads these.
+# Removed option, kept only so async_migrate_entry can strip it from entries
+# that predate v5. Nothing outside the migration reads it.
 CONF_AVAILABILITY_CHECK = "availability_check"
+# Consecutive failed polls before the device is reported unavailable; floored
+# at wfrac/device.py's AVAILABILITY_FAILURE_LIMIT_MIN.
 CONF_AVAILABILITY_RETRY_LIMIT = "availability_retry_limit"
 # Gates all outbound internet traffic (as opposed to local-network device
 # polling) - the manufacturer's getFirmware endpoint. Off by default: unlike

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -37,8 +37,6 @@
         "description": "Below are the options you can change for this airco.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "availability_check": "[%key:common::config_flow::data::avaiability%]",
-          "availability_retry_limit": "[%key:common::config_flow::data::avaiability_retry_limit%]",
           "firmware_update_check": "Firmware Update Check (Online)",
           "service_data": "Service Data",
           "target_offset_cool": "Target Temp. Offset (Cooling)",

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -37,6 +37,7 @@
         "description": "Below are the options you can change for this airco.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
+          "availability_retry_limit": "Retry limit (minimum 3)",
           "firmware_update_check": "Firmware Update Check (Online)",
           "service_data": "Service Data",
           "target_offset_cool": "Target Temp. Offset (Cooling)",

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -38,8 +38,6 @@
         "description": "Nachfolgend finden Sie die Optionen, die Sie für diese Klimaanlage ändern können.",
         "data": {
           "host": "Host (IP) Adresse",
-          "availability_check": "Verfügbarkeit prüfen",
-          "availability_retry_limit": "max. Anzahl Wiederholungen",
           "firmware_update_check": "Firmware-Update-Prüfung (Online)",
           "service_data": "Servicedaten",
           "create_swing_mode_select": "Ob zusätzliche Schwenkmodus-Auswahlen erstellt werden sollen.",

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -38,6 +38,7 @@
         "description": "Nachfolgend finden Sie die Optionen, die Sie für diese Klimaanlage ändern können.",
         "data": {
           "host": "Host (IP) Adresse",
+          "availability_retry_limit": "max. Anzahl Wiederholungen (mind. 3)",
           "firmware_update_check": "Firmware-Update-Prüfung (Online)",
           "service_data": "Servicedaten",
           "create_swing_mode_select": "Ob zusätzliche Schwenkmodus-Auswahlen erstellt werden sollen.",

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -38,6 +38,7 @@
         "description": "Below are the options you can change for this airco.",
         "data": {
           "host": "Host (IP) address",
+          "availability_retry_limit": "Retry limit (minimum 3)",
           "firmware_update_check": "Firmware Update Check (Online)",
           "service_data": "Service Data",
           "create_swing_mode_select": "Whether to create an additional swing mode selectors.",

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -38,8 +38,6 @@
         "description": "Below are the options you can change for this airco.",
         "data": {
           "host": "Host (IP) address",
-          "availability_check": "Check availability",
-          "availability_retry_limit": "Retry limit",
           "firmware_update_check": "Firmware Update Check (Online)",
           "service_data": "Service Data",
           "create_swing_mode_select": "Whether to create an additional swing mode selectors.",

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -38,6 +38,7 @@
         "description": "以下は、このエアコンの変更可能なオプションです。",
         "data": {
           "host": "ホスト（IP）アドレス",
+          "availability_retry_limit": "リトライ回数の上限（最小 3）",
           "create_swing_mode_select": "追加のスイングモードセレクターを作成するかどうか。",
           "indoor_offset": "室内オフセット",
           "outdoor_offset": "室外オフセット",

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -38,8 +38,6 @@
         "description": "以下は、このエアコンの変更可能なオプションです。",
         "data": {
           "host": "ホスト（IP）アドレス",
-          "availability_check": "可用性を確認",
-          "availability_retry_limit": "リトライ回数の上限",
           "create_swing_mode_select": "追加のスイングモードセレクターを作成するかどうか。",
           "indoor_offset": "室内オフセット",
           "outdoor_offset": "室外オフセット",

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -38,6 +38,7 @@
         "description": "Žemiau pateikiamos parinktys, kurias galite keisti šiam oro kondicionieriui.",
         "data": {
           "host": "Host (IP) adresas",
+          "availability_retry_limit": "Pakartotinio bandymo limitas (min. 3)",
           "create_swing_mode_select": "Ar kurti papildomus svyravimo režimo pasirinkiklius.",
           "indoor_offset": "Vidaus poslinkis",
           "outdoor_offset": "Lauko poslinkis",

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -38,8 +38,6 @@
         "description": "Žemiau pateikiamos parinktys, kurias galite keisti šiam oro kondicionieriui.",
         "data": {
           "host": "Host (IP) adresas",
-          "availability_check": "Patikrinti prieinamumą",
-          "availability_retry_limit": "Pakartotinio bandymo limitas",
           "create_swing_mode_select": "Ar kurti papildomus svyravimo režimo pasirinkiklius.",
           "indoor_offset": "Vidaus poslinkis",
           "outdoor_offset": "Lauko poslinkis",

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -38,6 +38,7 @@
         "description": "Hieronder zijn instellingen die je kan aanpassen voor deze airco.",
         "data": {
           "host": "Host (IP) address",
+          "availability_retry_limit": "Herhaal limiet (minimaal 3)",
           "create_swing_mode_select": "Of er extra zwaaimodus-selectors moeten worden aangemaakt.",
           "indoor_offset": "Binnen offset",
           "outdoor_offset": "Buiten offset",

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -38,8 +38,6 @@
         "description": "Hieronder zijn instellingen die je kan aanpassen voor deze airco.",
         "data": {
           "host": "Host (IP) address",
-          "availability_check": "Controleer beschikbaarheid",
-          "availability_retry_limit": "Herhaal limiet",
           "create_swing_mode_select": "Of er extra zwaaimodus-selectors moeten worden aangemaakt.",
           "indoor_offset": "Binnen offset",
           "outdoor_offset": "Buiten offset",

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -38,6 +38,7 @@
         "description": "以下是你可以为此空调更改的选项。",
         "data": {
           "host": "主机（IP）地址",
+          "availability_retry_limit": "重试次数上限（最少 3）",
           "create_swing_mode_select": "是否创建额外的摆风模式选择器。",
           "indoor_offset": "室内偏移",
           "outdoor_offset": "室外偏移",

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -38,8 +38,6 @@
         "description": "以下是你可以为此空调更改的选项。",
         "data": {
           "host": "主机（IP）地址",
-          "availability_check": "检查可用性",
-          "availability_retry_limit": "重试次数上限",
           "create_swing_mode_select": "是否创建额外的摆风模式选择器。",
           "indoor_offset": "室内偏移",
           "outdoor_offset": "室外偏移",

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -38,6 +38,7 @@
         "description": "以下是你可以為此空調更改的選項。",
         "data": {
           "host": "主機（IP）地址",
+          "availability_retry_limit": "重試次數上限（最少 3）",
           "create_swing_mode_select": "是否建立額外的擺風模式選擇器。",
           "indoor_offset": "室內偏移",
           "outdoor_offset": "室外偏移",

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -38,8 +38,6 @@
         "description": "以下是你可以為此空調更改的選項。",
         "data": {
           "host": "主機（IP）地址",
-          "availability_check": "檢查可用性",
-          "availability_retry_limit": "重試次數上限",
           "create_swing_mode_select": "是否建立額外的擺風模式選擇器。",
           "indoor_offset": "室內偏移",
           "outdoor_offset": "室外偏移",

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -38,13 +38,15 @@ FIRMWARE_CHECK_INTERVAL = timedelta(hours=24)
 # regular poll cadence. See Device._maybe_request_service_data().
 SERVICE_DATA_REQUEST_INTERVAL = MIN_TIME_BETWEEN_UPDATES
 
-# Consecutive failed polls before the device is reported unavailable. The
-# module reassociates to WiFi about once an hour and is unreachable while it
-# does (see the README's Troubleshooting section); reporting that as an outage
-# every time is noise. Three polls at MIN_TIME_BETWEEN_UPDATES is roughly three
-# minutes of grace, which rides through the reassociation without hiding a
-# device that is genuinely gone.
-AVAILABILITY_FAILURE_LIMIT = 3
+# Consecutive failed polls before the device is reported unavailable, and the
+# floor under the configurable value. The module reassociates to WiFi about
+# once an hour and is unreachable while it does (see the README's
+# Troubleshooting section); reporting that as an outage every time is noise.
+# Three polls at MIN_TIME_BETWEEN_UPDATES is roughly three minutes of grace,
+# which rides through the reassociation without hiding a device that is
+# genuinely gone. Raising it is a legitimate choice on a weak link; lowering it
+# only ever produced the phantom outages this floor exists to prevent.
+AVAILABILITY_FAILURE_LIMIT_MIN = 3
 
 
 class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attributes
@@ -60,6 +62,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             operator_id: str,
             airco_id: str,
             create_swing_mode_select: bool,
+            availability_failure_limit: int = AVAILABILITY_FAILURE_LIMIT_MIN,
             firmware_update_check_enabled: bool = False,
             service_data_enabled: bool = False,
             connection_method: str | None = None,
@@ -94,6 +97,12 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         self._service_data_enabled = service_data_enabled
         self._last_service_data_request: datetime | None = None
         self._consecutive_failures = 0
+        # Clamped rather than validated: an entry can carry a lower value from
+        # an older version, and refusing to set up over it would be worse than
+        # quietly giving it the tolerance it should have had.
+        self._availability_failure_limit = max(
+            AVAILABILITY_FAILURE_LIMIT_MIN, availability_failure_limit
+        )
         self._create_swing_mode_select = create_swing_mode_select
         # Serializes set_airco() calls end-to-end (snapshot build through
         # self._airco update) so a call can never build its diff from a
@@ -413,14 +422,14 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
 
     def _set_availability(self, available: bool):
         """Mark the device available, or unavailable once it has missed
-        AVAILABILITY_FAILURE_LIMIT polls in a row."""
+        self._availability_failure_limit polls in a row."""
         if available:
             self._consecutive_failures = 0
             self._available = True
             return
 
         self._consecutive_failures += 1
-        if self._consecutive_failures >= AVAILABILITY_FAILURE_LIMIT:
+        if self._consecutive_failures >= self._availability_failure_limit:
             self._consecutive_failures = 0
             self._available = False
 

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -38,6 +38,14 @@ FIRMWARE_CHECK_INTERVAL = timedelta(hours=24)
 # regular poll cadence. See Device._maybe_request_service_data().
 SERVICE_DATA_REQUEST_INTERVAL = MIN_TIME_BETWEEN_UPDATES
 
+# Consecutive failed polls before the device is reported unavailable. The
+# module reassociates to WiFi about once an hour and is unreachable while it
+# does (see the README's Troubleshooting section); reporting that as an outage
+# every time is noise. Three polls at MIN_TIME_BETWEEN_UPDATES is roughly three
+# minutes of grace, which rides through the reassociation without hiding a
+# device that is genuinely gone.
+AVAILABILITY_FAILURE_LIMIT = 3
+
 
 class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attributes
     """Device Class"""
@@ -51,8 +59,6 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             device_id: str,
             operator_id: str,
             airco_id: str,
-            availability_retry: bool,
-            availability_retry_limit: int,
             create_swing_mode_select: bool,
             firmware_update_check_enabled: bool = False,
             service_data_enabled: bool = False,
@@ -87,9 +93,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         self._firmware_update_check_enabled = firmware_update_check_enabled
         self._service_data_enabled = service_data_enabled
         self._last_service_data_request: datetime | None = None
-        self._availability_retry = availability_retry
-        self._availability_retry_count = 0
-        self._availability_retry_limit = availability_retry_limit
+        self._consecutive_failures = 0
         self._create_swing_mode_select = create_swing_mode_select
         # Serializes set_airco() calls end-to-end (snapshot build through
         # self._airco update) so a call can never build its diff from a
@@ -408,19 +412,16 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         self.async_set_updated_data(self._airco)
 
     def _set_availability(self, available: bool):
-        """Set availability after retry count"""
+        """Mark the device available, or unavailable once it has missed
+        AVAILABILITY_FAILURE_LIMIT polls in a row."""
         if available:
-            self._availability_retry_count = 0
+            self._consecutive_failures = 0
             self._available = True
             return
 
-        if not self._availability_retry:
-            self._available = False
-            return
-
-        self._availability_retry_count += 1
-        if self._availability_retry_count >= self._availability_retry_limit:
-            self._availability_retry_count = 0
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= AVAILABILITY_FAILURE_LIMIT:
+            self._consecutive_failures = 0
             self._available = False
 
     def set_available(self, available: bool):

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -34,8 +34,6 @@ async def device(hass):
         "device-id",
         "operator-id",
         "airco-id",
-        availability_retry=False,
-        availability_retry_limit=3,
         create_swing_mode_select=True,
     )
     dev._api = AsyncMock()

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -14,6 +14,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.mitsubishi_wf_rac.const import (
     CONF_AIRCO_ID,
+    CONF_AVAILABILITY_RETRY_LIMIT,
     CONF_FIRMWARE_UPDATE_CHECK,
     CONF_INDOOR_OFFSET,
     CONF_OPERATOR_ID,
@@ -377,6 +378,29 @@ async def test_options_flow_enforces_offset_range(hass: HomeAssistant, key, valu
 
     with pytest.raises(vol.MultipleInvalid):
         schema({"host": "192.168.1.50", key: value})
+
+
+async def test_options_flow_rejects_a_retry_limit_below_the_floor(hass: HomeAssistant):
+    # Values below the floor are what the v3 -> v4 and v4 -> v5 migrations kept
+    # having to correct; the form must not let a new one in.
+    import voluptuous as vol
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room AC"},
+        options={"host": "192.168.1.50"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    schema = result["data_schema"]
+
+    with pytest.raises(vol.MultipleInvalid):
+        schema({"host": "192.168.1.50", CONF_AVAILABILITY_RETRY_LIMIT: 1})
+
+    assert schema({"host": "192.168.1.50", CONF_AVAILABILITY_RETRY_LIMIT: 5})[
+        CONF_AVAILABILITY_RETRY_LIMIT
+    ] == 5
 
 
 async def test_options_flow_defaults_firmware_update_check_to_off(hass: HomeAssistant):

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -14,7 +14,6 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.mitsubishi_wf_rac.const import (
     CONF_AIRCO_ID,
-    CONF_AVAILABILITY_CHECK,
     CONF_FIRMWARE_UPDATE_CHECK,
     CONF_INDOOR_OFFSET,
     CONF_OPERATOR_ID,
@@ -317,7 +316,7 @@ async def test_options_flow_shows_form_with_current_defaults(hass: HomeAssistant
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50", CONF_AVAILABILITY_CHECK: True, CONF_TARGET_OFFSET: 1.5},
+        options={"host": "192.168.1.50", CONF_TARGET_OFFSET: 1.5},
     )
     entry.add_to_hass(hass)
 
@@ -339,8 +338,6 @@ async def test_options_flow_saves_submitted_values(hass: HomeAssistant):
         result["flow_id"],
         {
             "host": "192.168.1.50",
-            CONF_AVAILABILITY_CHECK: True,
-            "availability_retry_limit": 5,
             CONF_INDOOR_OFFSET: 1.0,
             CONF_OUTDOOR_OFFSET: -1.0,
             CONF_TARGET_OFFSET: 0.5,
@@ -379,7 +376,7 @@ async def test_options_flow_enforces_offset_range(hass: HomeAssistant, key, valu
     schema = result["data_schema"]
 
     with pytest.raises(vol.MultipleInvalid):
-        schema({"host": "192.168.1.50", CONF_AVAILABILITY_CHECK: True, key: value})
+        schema({"host": "192.168.1.50", key: value})
 
 
 async def test_options_flow_defaults_firmware_update_check_to_off(hass: HomeAssistant):
@@ -398,7 +395,7 @@ async def test_options_flow_defaults_firmware_update_check_to_off(hass: HomeAssi
     result = await hass.config_entries.options.async_init(entry.entry_id)
     schema = result["data_schema"]
 
-    validated = schema({"host": "192.168.1.50", CONF_AVAILABILITY_CHECK: True})
+    validated = schema({"host": "192.168.1.50"})
     assert validated[CONF_FIRMWARE_UPDATE_CHECK] is False
 
 
@@ -415,7 +412,6 @@ async def test_options_flow_saves_submitted_firmware_update_check(hass: HomeAssi
         result["flow_id"],
         {
             "host": "192.168.1.50",
-            CONF_AVAILABILITY_CHECK: True,
             CONF_FIRMWARE_UPDATE_CHECK: True,
         },
     )
@@ -437,7 +433,6 @@ async def test_options_flow_saves_submitted_per_mode_offsets(hass: HomeAssistant
         result["flow_id"],
         {
             "host": "192.168.1.50",
-            CONF_AVAILABILITY_CHECK: True,
             CONF_TARGET_OFFSET: 0.5,
             CONF_TARGET_OFFSET_COOL: 1.5,
             CONF_TARGET_OFFSET_HEAT: -1.5,
@@ -467,7 +462,6 @@ async def test_options_flow_leaves_per_mode_offsets_unset_when_omitted(hass: Hom
         result["flow_id"],
         {
             "host": "192.168.1.50",
-            CONF_AVAILABILITY_CHECK: True,
             CONF_TARGET_OFFSET: 0.5,
         },
     )

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -66,8 +66,6 @@ async def device(hass):
         "device-id",
         "operator-id",
         "airco-id",
-        availability_retry=False,
-        availability_retry_limit=3,
         create_swing_mode_select=True,
     )
     dev._api = AsyncMock()
@@ -295,10 +293,11 @@ async def test_delete_account_failure_returns_none(device):
     assert await device.delete_account() is None
 
 
-async def test_availability_retry_tolerates_failures_below_limit(hass):
+async def test_availability_tolerates_failures_below_limit(hass):
+    """The module reassociates to WiFi about once an hour and misses a poll
+    while it does; only a sustained run of failures is a real outage."""
     dev = Device(
         hass, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id",
-        availability_retry=True, availability_retry_limit=3,
         create_swing_mode_select=True,
     )
     dev._api = AsyncMock()
@@ -317,16 +316,31 @@ async def test_availability_retry_tolerates_failures_below_limit(hass):
     assert dev.available is False  # 3rd failure - limit reached
 
 
-async def test_availability_retry_disabled_fails_immediately(hass):
+async def test_availability_recovers_and_resets_the_failure_count(hass):
+    """A success in between must clear the run, not leave it part-way to the
+    limit."""
     dev = Device(
         hass, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id",
-        availability_retry=False, availability_retry_limit=3,
         create_swing_mode_select=True,
     )
     dev._api = AsyncMock()
-    dev._api.get_aircon_stats.side_effect = AirconApiError("boom")
     dev._api.update_account_info = AsyncMock()
+    dev._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await dev.update()
 
+    dev._api.get_aircon_stats.side_effect = AirconApiError("boom")
+    await dev.update()
+    await dev.update()
+    assert dev.available is True
+
+    dev._api.get_aircon_stats.side_effect = None
+    await dev.update()
+    assert dev.available is True
+
+    dev._api.get_aircon_stats.side_effect = AirconApiError("boom")
+    await dev.update()
+    await dev.update()
+    assert dev.available is True  # count restarted, not resumed at 2
     await dev.update()
     assert dev.available is False
 

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -13,7 +13,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.mitsubishi_wf_rac.wfrac import device as device_module
-from custom_components.mitsubishi_wf_rac.wfrac.device import Device
+from custom_components.mitsubishi_wf_rac.wfrac.device import (
+    AVAILABILITY_FAILURE_LIMIT_MIN,
+    Device,
+)
 from custom_components.mitsubishi_wf_rac.wfrac.models.aircon import AirconCommands
 from custom_components.mitsubishi_wf_rac.wfrac.rac_parser import RacParser
 from custom_components.mitsubishi_wf_rac.wfrac.repository import AirconApiError
@@ -314,6 +317,32 @@ async def test_availability_tolerates_failures_below_limit(hass):
     assert dev.available is True  # 2nd failure - still within tolerance
     await dev.update()
     assert dev.available is False  # 3rd failure - limit reached
+
+
+async def test_availability_limit_can_be_raised_but_not_lowered(hass):
+    """The option exists for weak links, where three minutes of grace isn't
+    enough. Below the floor it only ever produced phantom outages, so a lower
+    value is clamped rather than honoured."""
+    raised = Device(
+        hass, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id",
+        create_swing_mode_select=True, availability_failure_limit=5,
+    )
+    assert raised._availability_failure_limit == 5
+
+    lowered = Device(
+        hass, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id",
+        create_swing_mode_select=True, availability_failure_limit=1,
+    )
+    assert lowered._availability_failure_limit == AVAILABILITY_FAILURE_LIMIT_MIN
+
+    lowered._api = AsyncMock()
+    lowered._api.update_account_info = AsyncMock()
+    lowered._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await lowered.update()
+
+    lowered._api.get_aircon_stats.side_effect = AirconApiError("boom")
+    await lowered.update()
+    assert lowered.available is True  # would already be unavailable at limit 1
 
 
 async def test_availability_recovers_and_resets_the_failure_count(hass):

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -1,5 +1,8 @@
-"""Tests for __init__.py: config-entry migration and the availability-check
-default that create_device_from_entry() falls back to.
+"""Tests for __init__.py: config-entry migration.
+
+The availability options were removed in v5. Older steps still reference them
+because entries created under those versions carry the keys, but nothing reads
+them at runtime any more - the migration's job is to leave no trace of them.
 """
 
 from homeassistant.const import CONF_HOST
@@ -21,6 +24,8 @@ _DATA = {
     "port": 51443,
 }
 
+_CURRENT_VERSION = 5
+
 
 def _entry(hass: HomeAssistant, version: int, data: dict, options: dict) -> MockConfigEntry:
     entry = MockConfigEntry(domain=DOMAIN, version=version, data=data, options=options)
@@ -28,63 +33,43 @@ def _entry(hass: HomeAssistant, version: int, data: dict, options: dict) -> Mock
     return entry
 
 
-async def test_migrate_v1_moves_host_into_options_and_ends_at_v4(hass: HomeAssistant):
-    """A v1 entry runs through every step in one go. The v1 -> v2 step still
-    writes CONF_AVAILABILITY_CHECK False, but v3 -> v4 must turn it back on.
-    """
+async def test_migrate_v1_moves_host_into_options(hass: HomeAssistant):
+    """A v1 entry runs through every step in one go."""
     entry = _entry(hass, 1, {**_DATA, CONF_HOST: "192.168.1.50"}, {})
 
     assert await async_migrate_entry(hass, entry)
 
-    assert entry.version == 4
+    assert entry.version == _CURRENT_VERSION
     assert CONF_HOST not in entry.data
     assert entry.options[CONF_HOST] == "192.168.1.50"
-    assert entry.options[CONF_AVAILABILITY_CHECK] is True
-    assert entry.options[CONF_AVAILABILITY_RETRY_LIMIT] == 3
 
 
-async def test_migrate_v2_keeps_user_retry_limit(hass: HomeAssistant):
-    """The v2 -> v3 step used to reset the limit to 3 over whatever the user
-    had configured.
+async def test_migrate_drops_the_availability_options(hass: HomeAssistant):
+    """From any version that could carry them, including values the v3 -> v4
+    step used to correct rather than remove.
     """
-    entry = _entry(
-        hass,
-        2,
-        _DATA,
-        {CONF_HOST: "192.168.1.50", CONF_AVAILABILITY_CHECK: True, CONF_AVAILABILITY_RETRY_LIMIT: 8},
-    )
+    for version, options in (
+        (2, {CONF_AVAILABILITY_CHECK: True, CONF_AVAILABILITY_RETRY_LIMIT: 8}),
+        (3, {CONF_AVAILABILITY_CHECK: False, CONF_AVAILABILITY_RETRY_LIMIT: 0}),
+        (4, {CONF_AVAILABILITY_CHECK: False, CONF_AVAILABILITY_RETRY_LIMIT: 1}),
+    ):
+        entry = _entry(hass, version, _DATA, {CONF_HOST: "192.168.1.50", **options})
 
-    assert await async_migrate_entry(hass, entry)
+        assert await async_migrate_entry(hass, entry)
 
-    assert entry.version == 4
-    assert entry.options[CONF_AVAILABILITY_RETRY_LIMIT] == 8
-
-
-async def test_migrate_v3_enables_availability_check(hass: HomeAssistant):
-    entry = _entry(
-        hass,
-        3,
-        _DATA,
-        {CONF_HOST: "192.168.1.50", CONF_AVAILABILITY_CHECK: False, CONF_AVAILABILITY_RETRY_LIMIT: 3},
-    )
-
-    assert await async_migrate_entry(hass, entry)
-
-    assert entry.version == 4
-    assert entry.options[CONF_AVAILABILITY_CHECK] is True
+        assert entry.version == _CURRENT_VERSION
+        assert CONF_AVAILABILITY_CHECK not in entry.options
+        assert CONF_AVAILABILITY_RETRY_LIMIT not in entry.options
+        assert entry.options[CONF_HOST] == "192.168.1.50"
 
 
 async def test_migrate_v3_drops_dead_availability_retry_key(hass: HomeAssistant):
+    """The v1 -> v2 step used to write a key nothing ever read."""
     entry = _entry(
         hass,
         3,
         _DATA,
-        {
-            CONF_HOST: "192.168.1.50",
-            CONF_AVAILABILITY_CHECK: True,
-            CONF_AVAILABILITY_RETRY_LIMIT: 3,
-            "availability_retry": False,
-        },
+        {CONF_HOST: "192.168.1.50", "availability_retry": False},
     )
 
     assert await async_migrate_entry(hass, entry)
@@ -92,61 +77,35 @@ async def test_migrate_v3_drops_dead_availability_retry_key(hass: HomeAssistant)
     assert "availability_retry" not in entry.options
 
 
-async def test_migrate_v3_lifts_retry_limits_below_two(hass: HomeAssistant):
-    """0 and 1 both mean "give up on the first failed poll" in
-    Device._set_availability(), i.e. they cancel out the check being on.
-    """
-    for limit in (0, 1):
-        entry = _entry(
-            hass,
-            3,
-            _DATA,
-            {
-                CONF_HOST: "192.168.1.50",
-                CONF_AVAILABILITY_CHECK: False,
-                CONF_AVAILABILITY_RETRY_LIMIT: limit,
-            },
-        )
-
-        assert await async_migrate_entry(hass, entry)
-
-        assert entry.options[CONF_AVAILABILITY_RETRY_LIMIT] == 3
-
-
-async def test_migrate_v3_keeps_deliberate_higher_retry_limit(hass: HomeAssistant):
+async def test_migrate_keeps_unrelated_options(hass: HomeAssistant):
     entry = _entry(
         hass,
-        3,
+        4,
         _DATA,
-        {CONF_HOST: "192.168.1.50", CONF_AVAILABILITY_CHECK: False, CONF_AVAILABILITY_RETRY_LIMIT: 10},
+        {CONF_HOST: "192.168.1.50", "indoor_offset": -1.5, CONF_AVAILABILITY_CHECK: True},
     )
 
     assert await async_migrate_entry(hass, entry)
 
-    assert entry.options[CONF_AVAILABILITY_RETRY_LIMIT] == 10
-
-
-async def test_availability_check_defaults_to_on_when_key_missing(hass: HomeAssistant):
-    """The options form shows this as on for a missing key, so the runtime has
-    to agree - otherwise the form and the actual behaviour disagree.
-    """
-    entry = _entry(hass, 4, _DATA, {CONF_HOST: "192.168.1.50"})
-
-    device = await create_device_from_entry(entry, hass)
-
-    assert device._availability_retry is True  # pylint: disable=protected-access
-    assert device._availability_retry_limit == 3  # pylint: disable=protected-access
+    assert entry.options["indoor_offset"] == -1.5
 
 
 async def test_migrate_is_idempotent_at_current_version(hass: HomeAssistant):
-    options = {
-        CONF_HOST: "192.168.1.50",
-        CONF_AVAILABILITY_CHECK: False,
-        CONF_AVAILABILITY_RETRY_LIMIT: 1,
-    }
-    entry = _entry(hass, 4, _DATA, options)
+    options = {CONF_HOST: "192.168.1.50"}
+    entry = _entry(hass, _CURRENT_VERSION, _DATA, options)
 
     assert await async_migrate_entry(hass, entry)
 
-    assert entry.version == 4
+    assert entry.version == _CURRENT_VERSION
     assert entry.options == options
+
+
+async def test_device_is_built_without_availability_options(hass: HomeAssistant):
+    """Tolerance is a property of the module's behaviour, not a setting - an
+    entry carrying nothing but the host must still get it.
+    """
+    entry = _entry(hass, _CURRENT_VERSION, _DATA, {CONF_HOST: "192.168.1.50"})
+
+    device = await create_device_from_entry(entry, hass)
+
+    assert device._consecutive_failures == 0  # pylint: disable=protected-access

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -44,14 +44,16 @@ async def test_migrate_v1_moves_host_into_options(hass: HomeAssistant):
     assert entry.options[CONF_HOST] == "192.168.1.50"
 
 
-async def test_migrate_drops_the_availability_options(hass: HomeAssistant):
-    """From any version that could carry them, including values the v3 -> v4
-    step used to correct rather than remove.
+async def test_migrate_drops_the_check_and_floors_the_retry_limit(hass: HomeAssistant):
+    """From any version that could carry them. A limit above the floor is the
+    user's choice and survives; anything below it - including the check being
+    off, which was the same thing - comes out at the floor.
     """
-    for version, options in (
-        (2, {CONF_AVAILABILITY_CHECK: True, CONF_AVAILABILITY_RETRY_LIMIT: 8}),
-        (3, {CONF_AVAILABILITY_CHECK: False, CONF_AVAILABILITY_RETRY_LIMIT: 0}),
-        (4, {CONF_AVAILABILITY_CHECK: False, CONF_AVAILABILITY_RETRY_LIMIT: 1}),
+    for version, options, expected_limit in (
+        (2, {CONF_AVAILABILITY_CHECK: True, CONF_AVAILABILITY_RETRY_LIMIT: 8}, 8),
+        (3, {CONF_AVAILABILITY_CHECK: False, CONF_AVAILABILITY_RETRY_LIMIT: 0}, 3),
+        (4, {CONF_AVAILABILITY_CHECK: False, CONF_AVAILABILITY_RETRY_LIMIT: 1}, 3),
+        (4, {CONF_AVAILABILITY_CHECK: True}, 3),
     ):
         entry = _entry(hass, version, _DATA, {CONF_HOST: "192.168.1.50", **options})
 
@@ -59,7 +61,7 @@ async def test_migrate_drops_the_availability_options(hass: HomeAssistant):
 
         assert entry.version == _CURRENT_VERSION
         assert CONF_AVAILABILITY_CHECK not in entry.options
-        assert CONF_AVAILABILITY_RETRY_LIMIT not in entry.options
+        assert entry.options[CONF_AVAILABILITY_RETRY_LIMIT] == expected_limit
         assert entry.options[CONF_HOST] == "192.168.1.50"
 
 


### PR DESCRIPTION
`EnergyTotalResetButton` (button.py) had no `_update_state()`, unlike every
other `WfRacEntity` subclass. `WfRacEntity._handle_coordinator_update()`
calls `self._update_state()` unconditionally on each coordinator update, so
the missing method raised `AttributeError` on every poll - caught by the
base class's except clause as a real update failure, logging a warning and
marking the whole device unavailable via `Device.set_available(False)`.

Fixes #219