### PR TITLE
Keep a refused command from resetting the connection, and quiet transient unreachability

### DIFF
--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .firmware_check import fetch_latest_firmware
 from .rac_parser import RacParser
-from .repository import AirconApiError, Repository
+from .repository import AirconApiError, AirconConnectionError, Repository
 from .models.aircon import Aircon, AirconCommands, AirconStat, HomeLeaveModeSetting
 
 from ..const import DOMAIN, MIN_TIME_BETWEEN_UPDATES
@@ -145,6 +145,16 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
                 return
         except (AirconApiError, KeyError) as ex:
             self._set_availability(False)
+            # These modules restart their WiFi on their own, so a poll landing
+            # in that window is routine rather than a fault. Report it as one
+            # line and keep the traceback for debug; a unit that answered and
+            # then failed is the interesting case and keeps the full trace.
+            if isinstance(ex, AirconConnectionError):
+                _LOGGER.warning(
+                    "Could not reach the airco [%s]: %s", self.device_name, ex
+                )
+                _LOGGER.debug("Update of [%s] failed", self.device_name, exc_info=ex)
+                return
             _LOGGER.warning(
                 "Error: something went wrong updating the airco [%s] values",
                 self.device_name,
@@ -155,7 +165,10 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             # silently evict Home Assistant from that table, after which polls fail
             # until the integration is reloaded. Proactively re-register our account
             # on failure so we recover automatically on the next poll if we were
-            # evicted. add_account() is self-contained and swallows its own errors.
+            # evicted. An evicted account still answers (HTTP 400 / result:2, see
+            # Repository.get_aircon_stats), so this is skipped above when the unit
+            # was simply unreachable - re-registering can't succeed over a
+            # connection that isn't there. add_account() swallows its own errors.
             await self.add_account()
             return
 

--- a/custom_components/mitsubishi_wf_rac/wfrac/repository.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/repository.py
@@ -54,6 +54,26 @@ class AirconApiError(HomeAssistantError):
     """Raised when the aircon API returns an error"""
 
 
+class AirconCommandError(AirconApiError):
+    """Raised when the unit answered but refused the command itself.
+
+    Distinct from a transport failure: the module is reachable and the
+    protocol in use is the right one, it just declined this request (e.g.
+    HTTP 501 for an optional command). Callers use that difference to decide
+    whether the connection state is worth invalidating.
+    """
+
+
+class AirconConnectionError(AirconApiError):
+    """Raised when the unit could not be reached at all.
+
+    The counterpart to AirconCommandError: nothing answered, so neither the
+    request nor the account it was sent under can be judged from it. These
+    modules restart their WiFi periodically on their own, so single
+    occurrences are expected rather than a fault.
+    """
+
+
 class Repository:
     """Simple Api class to send and get Aircon information"""
 
@@ -153,12 +173,12 @@ class Repository:
                         body,
                     )
                     if resp.status >= 400:
-                        raise AirconApiError(
+                        raise AirconCommandError(
                             f"Aircon returned HTTP {resp.status} for {command!r}: {body}"
                         )
                     return json.loads(body)
             except (ClientConnectionError, asyncio.TimeoutError) as ex:
-                raise AirconApiError(f"Aircon returned error: {ex}") from ex
+                raise AirconConnectionError(f"Aircon returned error: {ex}") from ex
 
         data = {
             "apiVer": self.api_version,
@@ -181,6 +201,12 @@ class Repository:
             if self._method in ("http", "https"):
                 try:
                     json_response = await _execute_request(self._method)
+                except AirconCommandError:
+                    # The unit answered, so the stored method is still the
+                    # right one - it just refused this particular command.
+                    # Discarding the method here would cost every later
+                    # request an extra discovery round trip for nothing.
+                    raise
                 except AirconApiError:
                     # The unit may have rebooted, changed protocol, or the
                     # persisted method from a previous run may simply be stale -
@@ -198,6 +224,10 @@ class Repository:
             else:
                 _LOGGER.debug("No stored method; attempting discovery...")
                 try:
+                    # Deliberately falls back on any error, command errors
+                    # included: an HTTPS-only module can answer a plaintext
+                    # request with a status code rather than dropping the
+                    # connection, and that still means "try the other one".
                     json_response = await _execute_request("http")
                     _LOGGER.info("Discovered working communication method: HTTP")
                     # Store the required communication method

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -19,7 +19,11 @@ from custom_components.mitsubishi_wf_rac.wfrac.device import (
 )
 from custom_components.mitsubishi_wf_rac.wfrac.models.aircon import AirconCommands
 from custom_components.mitsubishi_wf_rac.wfrac.rac_parser import RacParser
-from custom_components.mitsubishi_wf_rac.wfrac.repository import AirconApiError
+from custom_components.mitsubishi_wf_rac.wfrac.repository import (
+    AirconApiError,
+    AirconCommandError,
+    AirconConnectionError,
+)
 
 from ..unit.live_captures import LIVE_CAPTURES
 
@@ -93,6 +97,34 @@ async def test_update_none_response_marks_unavailable(device):
 
 async def test_update_api_error_marks_unavailable_and_reregisters(device):
     device._api.get_aircon_stats.side_effect = AirconApiError("boom")
+    device._api.update_account_info = AsyncMock()
+    await device.update()
+    assert device.available is False
+    device._api.update_account_info.assert_awaited_once()
+
+
+async def test_update_unreachable_does_not_reregister(device, caplog):
+    """An account can only have been evicted by a unit that answered - after a
+    bare connection failure there is nothing to re-register against, and the
+    hourly WiFi restart these modules do would make it a recurring no-op.
+    """
+    device._api.get_aircon_stats.side_effect = AirconConnectionError("no route")
+    device._api.update_account_info = AsyncMock()
+    await device.update()
+    assert device.available is False
+    device._api.update_account_info.assert_not_awaited()
+    # One line for the user; the trace stays available on debug.
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert warnings[0].exc_info is None
+    assert any(r.exc_info for r in caplog.records if r.levelname == "DEBUG")
+
+
+async def test_update_refused_command_reregisters(device):
+    """An evicted account answers (HTTP 400 / result:2) rather than timing
+    out, so this path keeps the re-registration attempt.
+    """
+    device._api.get_aircon_stats.side_effect = AirconCommandError("refused")
     device._api.update_account_info = AsyncMock()
     await device.update()
     assert device.available is False

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -1,0 +1,129 @@
+"""Tests for wfrac/repository.py: how _post() classifies failures and what
+that classification does to the discovered communication method. The aiohttp
+session is replaced with a fake - no real network involved. Needs the `hass`
+fixture (Repository takes the HA client session from it), hence
+tests/integration/ rather than tests/unit/.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from aiohttp import ClientConnectionError
+
+from custom_components.mitsubishi_wf_rac.wfrac.repository import (
+    AirconCommandError,
+    AirconConnectionError,
+    Repository,
+)
+
+_OK_BODY = json.dumps({"result": 0, "contents": {"airconId": "airco-id"}})
+
+
+class _FakeResponse:
+    def __init__(self, status: int, body: str) -> None:
+        self.status = status
+        self.content_type = "application/json"
+        self._body = body
+
+    async def text(self) -> str:
+        return self._body
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *_exc) -> bool:
+        return False
+
+
+class _FakeSession:
+    """Answers every post with the next queued outcome, recording the URLs so
+    a test can tell which protocol was attempted.
+    """
+
+    def __init__(self, outcomes) -> None:
+        self._outcomes = list(outcomes)
+        self.urls: list[str] = []
+
+    def post(self, url: str, **_kwargs):
+        self.urls.append(url)
+        outcome = self._outcomes.pop(0) if self._outcomes else _OK_BODY
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+@pytest.fixture
+def repository(hass):
+    def _build(outcomes, method="http"):
+        with patch(
+            "custom_components.mitsubishi_wf_rac.wfrac.repository."
+            "async_get_clientsession"
+        ):
+            repo = Repository(
+                hass, "127.0.0.1", 51443, "operator-id", "device-id", method=method
+            )
+        session = _FakeSession(outcomes)
+        repo._session = session
+        return repo, session
+
+    return _build
+
+
+async def test_http_error_status_raises_command_error(repository):
+    repo, _ = repository([_FakeResponse(501, "Not supported this command")])
+    with pytest.raises(AirconCommandError):
+        await repo.get_aircon_stats("airco-id")
+
+
+async def test_connection_failure_raises_connection_error(repository):
+    repo, _ = repository([ClientConnectionError("boom")])
+    with pytest.raises(AirconConnectionError):
+        await repo.get_aircon_stats("airco-id")
+
+
+async def test_refused_command_keeps_the_discovered_method(repository):
+    """A 501 means the unit answered - the stored method is still correct, so
+    the next request must not pay for a rediscovery.
+    """
+    repo, session = repository(
+        [_FakeResponse(501, "Not supported this command"), _FakeResponse(200, _OK_BODY)]
+    )
+
+    with pytest.raises(AirconCommandError):
+        await repo.get_aircon_stats("airco-id")
+    assert repo.method == "http"
+
+    await repo.get_aircon_stats("airco-id")
+    assert session.urls == [
+        "http://127.0.0.1:51443/beaver/command/getAirconStat",
+        "http://127.0.0.1:51443/beaver/command/getAirconStat",
+    ]
+
+
+async def test_unreachable_unit_resets_the_discovered_method(repository):
+    """A dead transport says nothing about which protocol is right, so the
+    stored one is dropped and the next request rediscovers.
+    """
+    repo, _ = repository([ClientConnectionError("boom")])
+
+    with pytest.raises(AirconConnectionError):
+        await repo.get_aircon_stats("airco-id")
+    assert repo.method is None
+
+
+async def test_discovery_falls_back_to_https_on_a_command_error(repository):
+    """An HTTPS-only module can answer a plaintext request with a status code
+    rather than dropping the connection; discovery still has to try HTTPS.
+    """
+    repo, session = repository(
+        [_FakeResponse(400, "bad request"), _FakeResponse(200, _OK_BODY)], method=None
+    )
+
+    await repo.get_aircon_stats("airco-id")
+
+    assert repo.method == "https"
+    assert session.urls == [
+        "http://127.0.0.1:51443/beaver/command/getAirconStat",
+        "https://127.0.0.1:51443/beaver/command/getAirconStat",
+    ]


### PR DESCRIPTION
Log noise from #230, two independent causes. No functional change to what the integration does with the unit.

**A declined command discarded the connection state.** `_post()` treated every HTTP status >= 400 like a dead transport and cleared the discovered `http`/`https` method. But a status code means the unit answered over the right protocol and simply refused that request — as seen in #230, where the optional Service Data status request comes back `501 Not supported this command` while the next poll goes through fine. The reset cost an extra discovery round trip afterwards and logged an `INFO` about it every time.

Status errors now raise `AirconCommandError`, which leaves the stored method in place; only real transport failures (`AirconConnectionError`) still reset it. Discovery deliberately keeps falling back on either kind — an HTTPS-only module can answer a plaintext request with a status code rather than dropping the connection.

**A brief unreachable moment produced two warnings and a traceback.** These modules restart their WiFi on their own, so a poll landing in that window is routine. It logged a full aiohttp traceback, then ran the account re-registration, which failed against the same dead connection and warned a second time.

The re-registration exists because the module's account table can silently evict Home Assistant — but an evicted account *answers* (HTTP 400 / `result:2`, see `Repository.get_aircon_stats`), it doesn't time out. So it now runs only when the unit actually replied and refused us, and an unreachable unit is reported as one line with the traceback kept on debug.

Tests: new `tests/integration/test_repository.py` covers the classification and what each kind does to the stored method; two cases added in `test_device.py` for the re-registration split. 169 pass.