### PR TITLE
Stop losing and stop faking operation data

### DIFF
--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -57,6 +57,27 @@ SERVICE_DATA_REQUEST_OFFSET = SERVICE_DATA_REQUEST_INTERVAL / 2
 # refusals seen in #230 are transient, so one retry is worth the extra write.
 SERVICE_DATA_RETRY_DELAY = timedelta(seconds=5)
 
+# The unit answers these segments only when asked, so they are carried across
+# the polls in between (see Device._carry_forward_service_data()) - but not
+# indefinitely. A unit that keeps refusing the request (#230) would otherwise
+# leave entities reporting a frozen number indistinguishable from a live one,
+# which is worse for automations built on them than an honest gap.
+SERVICE_DATA_MAX_AGE = 3 * SERVICE_DATA_REQUEST_INTERVAL
+
+# Fields fed exclusively by those segments.
+SERVICE_DATA_FIELDS = (
+    "CompressorFrequency",
+    "OperatingCurrent",
+    "HotGasTemp",
+    "EevPulses",
+    "EevPosition",
+)
+
+# Matches the underlying HTTP request timeout. The WF-RAC adapter is slow and
+# frequently answers in 10-20s; a tighter coordinator timeout would cancel
+# slow-but-valid polls and report a device that was about to answer as failed.
+POLL_TIMEOUT = timedelta(seconds=30)
+
 # Consecutive failed polls before the device is reported unavailable, and the
 # floor under the configurable value. The module reassociates to WiFi about
 # once an hour and is unreachable while it does (see the README's
@@ -115,6 +136,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         self._firmware_update_check_enabled = firmware_update_check_enabled
         self._service_data_enabled = service_data_enabled
         self._last_service_data_request: datetime | None = None
+        self._last_service_data_response: datetime | None = None
         self._service_data_task: asyncio.Task | None = None
         self._consecutive_failures = 0
         # Clamped rather than validated: an entry can carry a lower value from
@@ -341,19 +363,25 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         """Same rationale as _carry_forward_home_leave_mode() above: the unit
         reports these extension segments exactly once (confirmed live
         06.08.2026, see todo.md), so without this the sensors would flash the
-        real value for one update cycle and then revert to unknown."""
+        real value for one update cycle and then revert to unknown.
+
+        Unlike home/leave mode this expires: see SERVICE_DATA_MAX_AGE.
+        """
         if self._airco is None:
             return
-        if new_airco.CompressorFrequency is None:
-            new_airco.CompressorFrequency = self._airco.CompressorFrequency
-        if new_airco.OperatingCurrent is None:
-            new_airco.OperatingCurrent = self._airco.OperatingCurrent
-        if new_airco.HotGasTemp is None:
-            new_airco.HotGasTemp = self._airco.HotGasTemp
-        if new_airco.EevPulses is None:
-            new_airco.EevPulses = self._airco.EevPulses
-        if new_airco.EevPosition is None:
-            new_airco.EevPosition = self._airco.EevPosition
+        now = datetime.now()
+        if any(getattr(new_airco, name) is not None for name in SERVICE_DATA_FIELDS):
+            self._last_service_data_response = now
+        elif (
+            self._last_service_data_response is None
+            or now - self._last_service_data_response > SERVICE_DATA_MAX_AGE
+        ):
+            # Nothing fresh for too long - leave the fields unset so entities
+            # report unknown rather than a value that stopped being true.
+            return
+        for name in SERVICE_DATA_FIELDS:
+            if getattr(new_airco, name) is None:
+                setattr(new_airco, name, getattr(self._airco, name))
 
     async def delete_account(self):
         """Delete account (operator id) from the airco"""
@@ -638,11 +666,15 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
     async def _async_update_data(self):
         """Update data via library."""
         try:
-            # Match the underlying HTTP request timeout (30s). The WF-RAC adapter
-            # is slow/flaky and frequently answers in 10-20s; a tighter coordinator
-            # timeout here would cancel slow-but-valid polls and mark the entity
-            # unavailable even though the unit was about to respond.
-            async with asyncio.timeout(30):
+            async with asyncio.timeout(POLL_TIMEOUT.total_seconds()):
                 await asyncio.gather(*[self.update()])
+        except asyncio.TimeoutError as error:
+            # Spelled out because str(TimeoutError()) is empty: the
+            # coordinator's own message would otherwise read "Error fetching
+            # <name> data:" and stop there, which says nothing at all.
+            raise UpdateFailed(
+                f"[{self.device_name}] did not answer within "
+                f"{POLL_TIMEOUT.total_seconds():.0f}s"
+            ) from error
         except Exception as error:
             raise UpdateFailed(error) from error

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -10,7 +10,12 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .firmware_check import fetch_latest_firmware
 from .rac_parser import RacParser
-from .repository import AirconApiError, AirconConnectionError, Repository
+from .repository import (
+    AirconApiError,
+    AirconCommandError,
+    AirconConnectionError,
+    Repository,
+)
 from .models.aircon import Aircon, AirconCommands, AirconStat, HomeLeaveModeSetting
 
 from ..const import DOMAIN, MIN_TIME_BETWEEN_UPDATES
@@ -37,6 +42,20 @@ FIRMWARE_CHECK_INTERVAL = timedelta(hours=24)
 # round trip (see todo.md), so there's no reason to throttle it below the
 # regular poll cadence. See Device._maybe_request_service_data().
 SERVICE_DATA_REQUEST_INTERVAL = MIN_TIME_BETWEEN_UPDATES
+
+# ...but it does matter *where* in the cycle it lands. Issued straight off the
+# back of a poll it reached the module about a second after the getAirconStat
+# (consolidation delay plus the minimum spacing between requests), and modules
+# answer a second request that soon with HTTP 501 "Not supported this command"
+# often enough to lose whole cycles of operation data - roughly one poll in
+# seven on the unit reported in #230, sometimes several minutes in a row.
+# Offsetting it into the quiet middle of the cycle keeps the cadence but stops
+# it from crowding the poll.
+SERVICE_DATA_REQUEST_OFFSET = SERVICE_DATA_REQUEST_INTERVAL / 2
+
+# A refused request costs a full cycle of every operation-data sensor, and the
+# refusals seen in #230 are transient, so one retry is worth the extra write.
+SERVICE_DATA_RETRY_DELAY = timedelta(seconds=5)
 
 # Consecutive failed polls before the device is reported unavailable, and the
 # floor under the configurable value. The module reassociates to WiFi about
@@ -96,6 +115,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         self._firmware_update_check_enabled = firmware_update_check_enabled
         self._service_data_enabled = service_data_enabled
         self._last_service_data_request: datetime | None = None
+        self._service_data_task: asyncio.Task | None = None
         self._consecutive_failures = 0
         # Clamped rather than validated: an entry can carry a lower value from
         # an older version, and refusing to set up over it would be worse than
@@ -262,16 +282,60 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         """
         if not self._service_data_enabled:
             return
+        if self._service_data_task is not None and not self._service_data_task.done():
+            # A retry from the previous cycle is still in flight; piling a
+            # second request on top is exactly the crowding this avoids.
+            return
         now = datetime.now()
         if (
             self._last_service_data_request is not None
             and now - self._last_service_data_request < SERVICE_DATA_REQUEST_INTERVAL
         ):
             return
+        # Stamped now, not when the request actually goes out, so the offset
+        # below shifts the request within the cycle instead of stretching the
+        # interval between requests.
         self._last_service_data_request = now
-        self._hass.async_create_task(
-            self.async_queue_command({AirconCommands.ServiceDataStatusRequest: True})
+        # Background task, not a plain one: it spends most of its life asleep
+        # waiting out the offset, and HA cancels background tasks at shutdown
+        # instead of waiting for them.
+        self._service_data_task = self._hass.async_create_background_task(
+            self._async_request_service_data(),
+            name=f"{DOMAIN} service data request {self._airco_id}",
         )
+
+    async def _async_request_service_data(self) -> None:
+        """Ask the unit for the operation-data block, offset from the poll and
+        retried once if the unit refuses it (see SERVICE_DATA_REQUEST_OFFSET
+        and #230). Sends directly rather than through async_queue_command() so
+        the refusal is visible here: a queued command is flushed by a detached
+        task that deliberately swallows its errors.
+        """
+        await asyncio.sleep(SERVICE_DATA_REQUEST_OFFSET.total_seconds())
+        params = {AirconCommands.ServiceDataStatusRequest: True}
+        for attempt in (1, 2):
+            try:
+                await self.set_airco(params, log_failure=False)
+                if attempt > 1:
+                    _LOGGER.debug("Service data request succeeded on retry")
+                return
+            except AirconCommandError as ex:
+                if attempt == 1:
+                    _LOGGER.debug("Service data request refused (%s); retrying", ex)
+                    await asyncio.sleep(SERVICE_DATA_RETRY_DELAY.total_seconds())
+                    continue
+                _LOGGER.warning(
+                    "Service data request refused twice, skipping this cycle "
+                    "for [%s]: %s",
+                    self.device_name,
+                    ex,
+                )
+            except (AirconApiError, KeyError, TypeError, ValueError):
+                # Unreachable or unparseable: the poll itself reports that, and
+                # this request is an optional extra on top of it.
+                return
+        # Entities keep their previous operation-data values on a skipped cycle
+        # (see _carry_forward_service_data), so there is nothing to push here.
 
     def _carry_forward_service_data(self, new_airco: Aircon) -> None:
         """Same rationale as _carry_forward_home_leave_mode() above: the unit
@@ -309,8 +373,15 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             _LOGGER.warning("Could not add account from airco %s", self._airco_id)
             return None
 
-    async def set_airco(self, params: dict[str, Any]) -> None:
-        """Method to send airco command"""
+    async def set_airco(
+        self, params: dict[str, Any], *, log_failure: bool = True
+    ) -> None:
+        """Method to send airco command.
+
+        log_failure=False leaves the reporting to the caller, for requests that
+        have their own retry and a quieter failure story than a user command
+        that never reached the unit - see _async_request_service_data().
+        """
         _LOGGER.debug("Setting airco: %s", params)
         # Held for the whole read-modify-send-update sequence, not just the
         # send: the snapshot below must only ever be built from self._airco
@@ -342,7 +413,8 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
                 self._carry_forward_service_data(new_airco)
                 self._airco = new_airco
             except (AirconApiError, KeyError, TypeError, ValueError) as ex:
-                _LOGGER.warning("Could not send airco data: %s", str(ex))
+                if log_failure:
+                    _LOGGER.warning("Could not send airco data: %s", str(ex))
                 raise
 
     async def async_queue_command(self, params: dict[str, Any]) -> None:

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -63,6 +63,21 @@ async def _echo_send_airco_command(_airco_id, command):
     return _build_stat_response(receive_content)
 
 
+def _shorten_service_data_timing(monkeypatch, offset_ms: int = 5) -> None:
+    """Collapse the real cadence (30s offset, 5s retry delay) to something a
+    test can wait out.
+    """
+    monkeypatch.setattr(
+        device_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5)
+    )
+    monkeypatch.setattr(
+        device_module, "SERVICE_DATA_REQUEST_OFFSET", timedelta(milliseconds=offset_ms)
+    )
+    monkeypatch.setattr(
+        device_module, "SERVICE_DATA_RETRY_DELAY", timedelta(milliseconds=5)
+    )
+
+
 @pytest.fixture
 async def device(hass):
     dev = Device(
@@ -523,7 +538,7 @@ async def test_update_does_not_request_service_data_when_disabled_by_default(dev
 
 async def test_update_requests_service_data_when_enabled(device, monkeypatch):
     device._service_data_enabled = True
-    monkeypatch.setattr(device_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
+    _shorten_service_data_timing(monkeypatch)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
 
@@ -533,9 +548,63 @@ async def test_update_requests_service_data_when_enabled(device, monkeypatch):
     device._api.send_airco_command.assert_awaited_once()
 
 
+async def test_service_data_request_is_offset_from_the_poll(device, monkeypatch):
+    """It must not ride straight off the back of the status poll - landing a
+    second write that close is what the unit refuses with HTTP 501 (#230).
+    """
+    device._service_data_enabled = True
+    _shorten_service_data_timing(monkeypatch, offset_ms=40)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
+
+    await device.update()
+    await asyncio.sleep(0.01)
+    device._api.send_airco_command.assert_not_awaited()
+
+    await asyncio.sleep(0.06)
+    device._api.send_airco_command.assert_awaited_once()
+
+
+async def test_service_data_request_is_retried_once_when_refused(device, monkeypatch):
+    device._service_data_enabled = True
+    _shorten_service_data_timing(monkeypatch)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    calls = []
+
+    async def _refuse_then_answer(airco_id, command):
+        calls.append(command)
+        if len(calls) == 1:
+            raise AirconCommandError("HTTP 501: Not supported this command")
+        return await _echo_send_airco_command(airco_id, command)
+
+    device._api.send_airco_command = AsyncMock(side_effect=_refuse_then_answer)
+
+    await device.update()
+    await asyncio.sleep(0.1)
+
+    assert len(calls) == 2
+
+
+async def test_service_data_request_gives_up_after_the_retry(device, monkeypatch, caplog):
+    device._service_data_enabled = True
+    _shorten_service_data_timing(monkeypatch)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    device._api.send_airco_command = AsyncMock(
+        side_effect=AirconCommandError("HTTP 501: Not supported this command")
+    )
+
+    await device.update()
+    await asyncio.sleep(0.1)
+
+    assert device._api.send_airco_command.await_count == 2
+    # One warning for the cycle, not one per attempt.
+    refusals = [r for r in caplog.records if "refused twice" in r.message]
+    assert len(refusals) == 1
+
+
 async def test_update_service_data_request_is_rate_limited(device, monkeypatch):
     device._service_data_enabled = True
-    monkeypatch.setattr(device_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
+    _shorten_service_data_timing(monkeypatch)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
 

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -7,7 +7,7 @@ than tests/unit/.
 
 import asyncio
 import base64
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -17,7 +17,7 @@ from custom_components.mitsubishi_wf_rac.wfrac.device import (
     AVAILABILITY_FAILURE_LIMIT_MIN,
     Device,
 )
-from custom_components.mitsubishi_wf_rac.wfrac.models.aircon import AirconCommands
+from custom_components.mitsubishi_wf_rac.wfrac.models.aircon import Aircon, AirconCommands
 from custom_components.mitsubishi_wf_rac.wfrac.rac_parser import RacParser
 from custom_components.mitsubishi_wf_rac.wfrac.repository import (
     AirconApiError,
@@ -625,3 +625,66 @@ async def test_async_update_data_wraps_exception_in_update_failed(device):
     device.update = _boom
     with pytest.raises(UpdateFailed):
         await device._async_update_data()
+
+
+async def test_async_update_data_names_the_timeout(device, monkeypatch):
+    """str(TimeoutError()) is empty, so without a message of our own the
+    coordinator logs "Error fetching <name> data:" and nothing else.
+    """
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+
+    monkeypatch.setattr(device_module, "POLL_TIMEOUT", timedelta(milliseconds=10))
+
+    async def _hang():
+        await asyncio.sleep(5)
+
+    device.update = _hang
+    with pytest.raises(UpdateFailed) as excinfo:
+        await device._async_update_data()
+
+    assert str(excinfo.value)
+    assert "did not answer" in str(excinfo.value)
+
+
+# --- service data is carried between polls, but not forever ---------------
+
+
+async def test_service_data_is_carried_forward_between_polls(device):
+    device._airco.CompressorFrequency = 40.0
+    device._last_service_data_response = datetime.now()
+    new_airco = Aircon()
+
+    device._carry_forward_service_data(new_airco)
+
+    assert new_airco.CompressorFrequency == 40.0
+
+
+async def test_service_data_expires_when_nothing_fresh_arrives(device):
+    """A unit that keeps refusing the request (#230) must not leave entities
+    reporting a frozen value that looks live.
+    """
+    device._airco.CompressorFrequency = 40.0
+    device._last_service_data_response = datetime.now() - (
+        device_module.SERVICE_DATA_MAX_AGE + timedelta(seconds=1)
+    )
+    new_airco = Aircon()
+
+    device._carry_forward_service_data(new_airco)
+
+    assert new_airco.CompressorFrequency is None
+
+
+async def test_fresh_service_data_restarts_the_clock(device):
+    device._airco.CompressorFrequency = 40.0
+    device._airco.HotGasTemp = 50.0
+    device._last_service_data_response = datetime.now() - (
+        device_module.SERVICE_DATA_MAX_AGE + timedelta(seconds=1)
+    )
+    new_airco = Aircon()
+    new_airco.CompressorFrequency = 45.0  # this poll carried the segments
+
+    device._carry_forward_service_data(new_airco)
+
+    assert new_airco.CompressorFrequency == 45.0
+    # The rest of the block comes with it, so they are carried again.
+    assert new_airco.HotGasTemp == 50.0


### PR DESCRIPTION
Everything that came out of #230 apart from the log-noise cleanup already merged in #231. Replaces #232, which GitHub closed automatically when its base branch was deleted on merge — same two commits, rebuilt on `main`, reviewable separately.

## The request was crowding the poll (`501`)

The operation-data request is a second `setAirconStat` on top of each status poll, and it was fired at the end of `update()`. With the 500 ms consolidation delay and the one-second minimum spacing between requests, that put it about a second behind the `getAirconStat` — visible in the reporter's log as the `Waiting for 0.498007s` line immediately before the refusal. Asking the module for something else a second after it just answered is a good way to be told `Not supported this command`, and on the unit in #230 that costs roughly one poll in seven, sometimes several minutes in a row.

- **Offset**: the request waits out half the poll interval, so it lands in the quiet middle of the cycle. The cadence is unchanged — the interval is stamped at poll time, so the offset shifts the request within the cycle rather than stretching the gap between requests.
- **Retry**: a refusal is retried once after five seconds instead of writing off the cycle. It sends through `set_airco()` directly rather than `async_queue_command()`, because the queued path is flushed by a detached task that deliberately swallows its errors — the refusal would never reach a retry from there. `set_airco()` gained a `log_failure` flag so the failure is reported once per skipped cycle by the caller, not once per attempt.
- It runs as a background task, so Home Assistant cancels it at shutdown rather than waiting out the offset sleep.

## Two things the integration failed to tell the user

- **A timeout said nothing.** A coordinator timeout was wrapped as `UpdateFailed(TimeoutError())`, and `str(TimeoutError())` is empty — so a poll running past 30 seconds was logged as `Error fetching <name> data:` and stopped there. It now names the device and the wait, and the timeout is a named constant next to the comment that explains it.
- **Stale values looked live.** Operation-data values are only refreshed when a service-data request succeeds, and were carried across the polls in between with no expiry. On a unit that keeps refusing the request, the sensors kept reporting a frozen number indistinguishable from a real one — worse for automations built on them than an honest gap. They now expire after three missed cycles and fall back to unknown; any response carrying the segments restarts the clock.

The affected fields moved into `SERVICE_DATA_FIELDS`, so adding an operation-data sensor no longer means remembering to extend an if-chain.

Tests: offset, retry, give-up path, unchanged rate limit, the named timeout, and the carry-forward expiry. 176 pass.