### PR TITLE
Prepare 2026.9.3-beta1 pre-release

### DIFF
--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues",
   "requirements": [],
-  "version": "2026.9.2",
+  "version": "2026.9.3-beta1",
   "zeroconf": [
     "_beaver._tcp.local."
   ]


### PR DESCRIPTION
Version bump only.

Contents: #231 (a declined command no longer resets the discovered protocol; a brief unreachable moment logs one line instead of a traceback and no longer triggers a second warning from the account re-registration) and #233 (the operation-data request moves to the middle of the poll cycle and is retried once when refused; the poll timeout says which device did not answer; carried-forward operation data expires after three missed cycles instead of reporting a stale value forever).

Pre-release because the operation-data expiry is a visible behaviour change for anyone with Service Data on, and because the `501` fix can only be confirmed on hardware that shows the problem — see #230.