### PR TITLE
Describe protective-stop codes, and correct three error descriptions

### DIFF
--- a/custom_components/mitsubishi_wf_rac/binary_sensor.py
+++ b/custom_components/mitsubishi_wf_rac/binary_sensor.py
@@ -56,8 +56,11 @@ class ProblemBinarySensor(WfRacEntity, BinarySensorEntity):
         self._attr_is_on = code != "00"
         attrs: dict[str, str] = {"error_code": code}
         # Deliberately no key at all (rather than a guessed/empty value) for
-        # undocumented codes - every M<n> maintenance code, and any E-number
-        # outside fehlercodes-selfdiagnose.md's tables.
+        # codes outside fehlercodes-selfdiagnose.md's tables.
+        # NB this still reports is_on for an M<n> code, which is a protective
+        # stop the unit recovered from rather than a fault it is displaying -
+        # arguably not a "problem". Left as it was for now; changing it would
+        # alter what existing automations see.
         description = describe_error_code(code)
         if description is not None:
             attrs["error_description"] = description

--- a/custom_components/mitsubishi_wf_rac/wfrac/error_codes.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/error_codes.py
@@ -1,51 +1,86 @@
 """Klartext descriptions for the self-diagnosis ErrorCode (rac_parser.py).
 
 Source and confidence notes: ../../../../fehlercodes-selfdiagnose.md
-(transcribed from the official MHI service/user manuals). Not hardware-
-verified against a real E<n> occurrence - only cross-checked between the two
-manuals.
+(transcribed from the official MHI service/user manuals and, since 09.08.2026,
+the SRK databooks). Not hardware-verified against a real occurrence - only
+cross-checked between documents.
+
+The unit numbers errors and protective stops out of one shared space (the
+databooks' "Error code, stop code table"), which is why the same number is
+described once here and reused for both spellings: E<n> is the escalated,
+displayed fault, M<n> the protective stop that has not (yet) escalated - see
+describe_error_code().
 """
 
 from typing import Final
 
-# High confidence: outdoor unit/refrigeration-circuit codes. Wording and
-# blink-pattern position match word-for-word between the SRR service manual
-# (source of these E-numbers) and the SRK user's manual (Daniel's own model
-# family, SRK35ZS-WF) - the outdoor unit/refrigeration circuit is the same
-# platform across indoor unit form factors.
+# High confidence: present with matching wording in the SRR service manual, the
+# SRK user's manual and the ZS-WF/ZSX-WF/ZR-WF databooks. The databook tables
+# are word-for-word identical across those three series, so these are not
+# specific to one model family.
 _HIGH_CONFIDENCE: Final[dict[str, str]] = {
-    "E1": "Fehler Kabel-Fernbedienung",
-    "E5": "Signalübertragungsfehler Indoor/Outdoor",
-    "E35": "Kühl-Hochdruckschutz",
-    "E36": "Verdichter-Übertemperatur",
-    "E37": "Außenwärmetauscher-Sensor-Fehler",
-    "E38": "Außenlufttemperatur-Sensor-Fehler",
-    "E39": "Druckgasleitungs-Sensor-Fehler",
-    "E40": "Absperrventil (Gasseite) geschlossen",
-    "E42": "Current Cut (Startstrom-Abschaltung)",
-    "E47": "Active-Filter-Spannungsfehler",
-    "E48": "Außenlüfter-Fehler",
-    "E51": "Leistungstransistor-Fehler",
-    "E57": "Kältekreis-Schutzabschaltung",
-    "E58": "Current-Safe-Abschaltung",
-    "E59": "Störung Außeneinheit",
-    "E60": "Rotor-Blockade",
+    "1": "Fehler Kabel-Fernbedienung",
+    "5": "Signalübertragungsfehler Indoor/Outdoor",
+    "35": "Kühl-Hochdruckschutz",
+    "36": "Verdichter-Übertemperatur (110 °C)",
+    "37": "Außenwärmetauscher-Sensor-Fehler",
+    "38": "Außenlufttemperatur-Sensor-Fehler",
+    "39": "Druckgasleitungs-Sensor-Fehler",
+    "40": "Absperrventil (Gasseite) geschlossen",
+    "42": "Current Cut (Startstrom-Abschaltung)",
+    "47": "Active-Filter-Spannungsfehler",
+    "48": "Außenlüfter-Fehler",
+    "51": "Leistungstransistor-Fehler",
+    "57": "Kältekreis-Schutzabschaltung",
+    "58": "Current-Safe-Abschaltung",
+    # Was "Störung Außeneinheit" until the databooks named the actual causes.
+    "59": "Verdichter-Verkabelung unterbrochen / Spannungseinbruch",
+    "61": "Verbindungsleitungen Innen-/Außeneinheit fehlerhaft",
+    "62": "Serielle Übertragungsstörung",
+    "80": "Innenlüfter-Motor gestört",
+    "82": "Innenwärmetauscher-Sensor-Fehler",
+    "84": "Kondensationsschutz aktiv",
+    "85": "Frostschutz aktiv",
+    "86": "Heiz-Hochdruckschutz aktiv",
 }
 
-# Medium confidence: blink-pattern position matches between the two manuals,
-# but the E-number itself is only confirmed for a different indoor unit
-# form factor (E9: SRR series, explicitly marked "SRR series only" in the
-# service manual) or not cross-checked at all (E16, no E-number in the SRK
-# manual to compare against).
+# Medium confidence: the number is confirmed for a different indoor unit form
+# factor only (9: SRR series, explicitly marked "SRR series only" in the
+# service manual), or it appears in no databook table at all (16 is the SRR
+# indoor fan motor number - the SRK tables use 80 for that; 60 has no entry in
+# any of the three).
 _MEDIUM_CONFIDENCE: Final[dict[str, str]] = {
-    "E9": "Drain-Störung (Service-Manual: nur SRR-Baureihe, für SRK unbestätigt)",
-    "E16": "Innenlüfter-Fehler (Nummer nicht am SRK selbst verifiziert)",
+    "9": "Drain-Störung (Service-Manual: nur SRR-Baureihe, für SRK unbestätigt)",
+    "16": "Innenlüfter-Fehler (SRR-Nummer; SRK meldet dafür 80)",
+    "60": "Rotor-Blockade (in keiner Databook-Tabelle belegt)",
 }
 
 
 def describe_error_code(code: str) -> str | None:
-    """Klartext description for an E<n> ErrorCode, or None if undocumented
-    (every M<n> maintenance code, and any E-number outside the tables above -
-    deliberately no text there rather than guessing, see
-    fehlercodes-selfdiagnose.md)."""
-    return _HIGH_CONFIDENCE.get(code) or _MEDIUM_CONFIDENCE.get(code)
+    """Klartext description for an E<n> or M<n> code, or None if undocumented.
+
+    Both spellings resolve through the same table: the unit numbers protective
+    stops and displayed faults out of one space, so M35 and E35 are the same
+    condition at different escalation stages (the databooks' auto-recovery
+    column gives the count - e.g. cooling high pressure control after 5
+    occurrences, compressor overheat after 2). M codes are prefixed so the
+    distinction survives into the UI, since a protective stop that recovered on
+    its own is not the same news as a fault the unit is displaying.
+
+    Anything outside the tables gets no text rather than a guess - see
+    fehlercodes-selfdiagnose.md.
+    """
+    if not code or code == "00":
+        return None
+    prefix, number = code[0], code[1:]
+    if prefix not in ("E", "M") or not number.isdigit():
+        return None
+    # rac_parser spells M codes zero-padded ("M01") and E codes bare ("E1"),
+    # so normalise before the lookup rather than keying both spellings.
+    number = str(int(number))
+    description = _HIGH_CONFIDENCE.get(number) or _MEDIUM_CONFIDENCE.get(number)
+    if description is None:
+        return None
+    if prefix == "M":
+        return f"Schutzabschaltung: {description}"
+    return description

--- a/tests/unit/test_error_codes.py
+++ b/tests/unit/test_error_codes.py
@@ -18,9 +18,20 @@ def test_describe_error_code_no_error_returns_none():
     assert describe_error_code("00") is None
 
 
-def test_describe_error_code_maintenance_code_returns_none():
-    # M<n> codes have no documented table at all (see fehlercodes-selfdiagnose.md).
-    assert describe_error_code("M01") is None
+def test_describe_maintenance_code_uses_the_shared_number_space():
+    # Errors and protective stops are numbered out of one table, so M35 is the
+    # same condition as E35 at an earlier escalation stage.
+    assert describe_error_code("M35") == "Schutzabschaltung: Kühl-Hochdruckschutz"
+
+
+def test_describe_maintenance_code_normalises_the_zero_padding():
+    # rac_parser spells M codes "M01" but E codes "E1", and both mean code 1.
+    assert describe_error_code("M01") == "Schutzabschaltung: Fehler Kabel-Fernbedienung"
+
+
+def test_describe_error_code_indoor_side_codes_from_the_databooks():
+    assert describe_error_code("E85") == "Frostschutz aktiv"
+    assert describe_error_code("E86") == "Heiz-Hochdruckschutz aktiv"
 
 
 def test_describe_error_code_undocumented_e_number_returns_none():


### PR DESCRIPTION
Relates to #225. New source: the MHI databooks collected and shared by @alexnikgr — thanks for those, they answered more than the question I asked.

They carry an **"Error code, stop code table"**, and it is word-for-word identical across ZS-WF, ZSX-WF and ZR-WF, so it is not specific to one model family. Two things follow from it.

**Displayed faults and protective stops share one number space.** That closes the gap the `M<n>` codes had: they had no documented source at all, so every one of them reached the user as a bare string with no text. `M35` and `E35` are now understood as the same condition at different escalation stages — the table's auto-recovery column even gives the counts (cooling high pressure control after 5 occurrences, compressor overheat after 2). Both spellings resolve through one table now, with `M` prefixed as `Schutzabschaltung:` so a stop the unit recovered from stays distinguishable from a fault it is displaying. (`rac_parser` spells M codes zero-padded and E codes bare, so the number is normalised before the lookup.)

**Seven codes were missing and three were wrong.**

- New: `61` and `62` (indoor/outdoor wiring and serial transmission), and the indoor-side `80`, `82`, `84`, `85`, `86` — none of which appear in any service or user manual I had.
- `59` was "Störung Außeneinheit", a guess at a vague entry; the databooks name it as compressor wiring disconnected / voltage drop.
- `16` came from the SRR service manual; the SRK tables use `80` for the indoor fan motor, so its caveat now says so.
- `60` appears in none of the three tables and drops to medium confidence.

Deliberately unchanged: the problem binary sensor still reports `is_on` for an `M` code. A protective stop the unit recovered from arguably is not a "problem", but changing that would alter what existing automations see, so it is a separate decision — noted in the code.

Tests: 178 pass.