### PR TITLE
Improve offline handling and automatic recovery

### DIFF
--- a/custom_components/mitsubishi_wf_rac/entity.py
+++ b/custom_components/mitsubishi_wf_rac/entity.py
@@ -1,6 +1,7 @@
 """Shared base entity for all WF-RAC platform entities."""
 
 from __future__ import annotations
+
 import logging
 
 from homeassistant.core import callback
@@ -29,9 +30,9 @@ class WfRacEntity(CoordinatorEntity[Device]):
     @property
     def available(self) -> bool:
         # Device tracks its own retry-tolerant availability (see
-        # Device._set_availability()); update() never raises, so
-        # CoordinatorEntity's default (coordinator.last_update_success) would
-        # otherwise stay True even while the device is actually unreachable.
+        # Device._set_availability()). The coordinator reports every failed
+        # poll through last_update_success, while entities deliberately remain
+        # available until the device's failure threshold is reached.
         return self._device.available
 
     @callback

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -1,14 +1,17 @@
 """Device module"""
+
 import asyncio
+import logging
 from datetime import datetime, timedelta
 from typing import Any
-import logging
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from ..const import DOMAIN, MIN_TIME_BETWEEN_UPDATES
 from .firmware_check import fetch_latest_firmware
+from .models.aircon import Aircon, AirconCommands, AirconStat, HomeLeaveModeSetting
 from .rac_parser import RacParser
 from .repository import (
     AirconApiError,
@@ -16,9 +19,6 @@ from .repository import (
     AirconConnectionError,
     Repository,
 )
-from .models.aircon import Aircon, AirconCommands, AirconStat, HomeLeaveModeSetting
-
-from ..const import DOMAIN, MIN_TIME_BETWEEN_UPDATES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -89,6 +89,35 @@ POLL_TIMEOUT = timedelta(seconds=30)
 AVAILABILITY_FAILURE_LIMIT_MIN = 3
 
 
+class _ExpectedPollError(UpdateFailed):
+    """A failed device poll already handled by the availability policy."""
+
+
+class _CoordinatorLogger(logging.LoggerAdapter):
+    """Keep expected transient poll failures out of the regular error log."""
+
+    def __init__(self, logger: logging.Logger) -> None:
+        super().__init__(logger, {})
+        self._quiet_failure_pending_recovery = False
+
+    def error(self, msg, *args, **kwargs) -> None:
+        if args and isinstance(args[-1], _ExpectedPollError):
+            self._quiet_failure_pending_recovery = True
+            self.debug(msg, *args, **kwargs)
+            return
+        super().error(msg, *args, **kwargs)
+
+    def info(self, msg, *args, **kwargs) -> None:
+        if (
+            msg == "Fetching %s data recovered"
+            and self._quiet_failure_pending_recovery
+        ):
+            self._quiet_failure_pending_recovery = False
+            self.debug(msg, *args, **kwargs)
+            return
+        super().info(msg, *args, **kwargs)
+
+
 class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attributes
     """Device Class"""
 
@@ -156,12 +185,12 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
 
         super().__init__(
             hass,
-            _LOGGER,
+            _CoordinatorLogger(_LOGGER),
             name=name,
             update_interval=MIN_TIME_BETWEEN_UPDATES,
         )
 
-    async def update(self):
+    async def update(self) -> bool:
         """Update the device information from API.
 
         Called both directly (initial fetch in __init__.py before entities
@@ -184,10 +213,10 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             if response is None:
                 self._set_availability(False)
                 _LOGGER.warning("Received no data for device %s", self._airco_id)
-                return
+                return False
         except AirconConnectionError as ex:
             self._record_connection_failure(ex)
-            return
+            return False
         except (AirconApiError, KeyError) as ex:
             self._set_availability(False)
             _LOGGER.warning(
@@ -205,7 +234,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             # was simply unreachable - re-registering can't succeed over a
             # connection that isn't there. add_account() swallows its own errors.
             await self.add_account()
-            return
+            return False
 
         try:
             self._connected_accounts = int(response["numOfAccount"])
@@ -226,7 +255,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         except (KeyError, TypeError, ValueError) as ex:
             _LOGGER.warning("Could not parse airco data", exc_info=ex)
             self._set_availability(False)
-            return
+            return False
 
         # Cosmetic (diagnostic sensor only). Some firmware revisions omit the
         # "mcu"/"wireless" sub-keys entirely (see #189), so their versions are
@@ -240,6 +269,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         self._wireless_firmware_ver = (response.get("wireless") or {}).get("firmVer")
         self._maybe_check_firmware_update()
         self._maybe_request_service_data()
+        return True
 
     def _maybe_check_firmware_update(self) -> None:
         """Kick off a background cloud firmware check if one is due (see
@@ -566,6 +596,11 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
                 self._availability_failure_limit,
             )
             _LOGGER.debug("Update of [%s] failed", self.device_name, exc_info=error)
+            # The coordinator only notifies listeners when its own success
+            # state changes. It already changed on the first missed poll, so
+            # reaching our later device-availability threshold would otherwise
+            # leave entities displaying their restored/last-known state.
+            self.async_update_listeners()
         else:
             _LOGGER.debug(
                 "Could not reach the airco [%s]: %s", self.device_name, error
@@ -692,16 +727,19 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         """Update data via library."""
         try:
             async with asyncio.timeout(POLL_TIMEOUT.total_seconds()):
-                await asyncio.gather(*[self.update()])
-        except asyncio.TimeoutError:
+                update_succeeded = await self.update()
+        except asyncio.TimeoutError as error:
             # The outer deadline can expire before the repository's individual
             # connection attempts do. Treat that exactly like any other missed
             # poll so transient outages stay quiet and the entity only becomes
             # unavailable at the configured threshold.
-            self._record_connection_failure(
-                AirconConnectionError(
-                    f"did not answer within {POLL_TIMEOUT.total_seconds():.0f}s"
-                )
+            connection_error = AirconConnectionError(
+                f"did not answer within {POLL_TIMEOUT.total_seconds():.0f}s"
             )
+            self._record_connection_failure(connection_error)
+            raise _ExpectedPollError(str(connection_error)) from error
         except Exception as error:
             raise UpdateFailed(error) from error
+
+        if not update_succeeded:
+            raise _ExpectedPollError(f"Poll of [{self.device_name}] failed")

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -185,18 +185,11 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
                 self._set_availability(False)
                 _LOGGER.warning("Received no data for device %s", self._airco_id)
                 return
+        except AirconConnectionError as ex:
+            self._record_connection_failure(ex)
+            return
         except (AirconApiError, KeyError) as ex:
             self._set_availability(False)
-            # These modules restart their WiFi on their own, so a poll landing
-            # in that window is routine rather than a fault. Report it as one
-            # line and keep the traceback for debug; a unit that answered and
-            # then failed is the interesting case and keeps the full trace.
-            if isinstance(ex, AirconConnectionError):
-                _LOGGER.warning(
-                    "Could not reach the airco [%s]: %s", self.device_name, ex
-                )
-                _LOGGER.debug("Update of [%s] failed", self.device_name, exc_info=ex)
-                return
             _LOGGER.warning(
                 "Error: something went wrong updating the airco [%s] values",
                 self.device_name,
@@ -227,7 +220,9 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             self._account_expires = response.get("expires")
             self._led_status = response.get("ledStat")
             self._auto_heating = response.get("autoHeating")
-            self._set_availability(True)
+            became_available = self._set_availability(True)
+            if became_available:
+                _LOGGER.info("Airco [%s] is available again", self.device_name)
         except (KeyError, TypeError, ValueError) as ex:
             _LOGGER.warning("Could not parse airco data", exc_info=ex)
             self._set_availability(False)
@@ -533,18 +528,48 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         # MIN_TIME_BETWEEN_UPDATES later).
         self.async_set_updated_data(self._airco)
 
-    def _set_availability(self, available: bool):
+    def _set_availability(self, available: bool) -> bool:
         """Mark the device available, or unavailable once it has missed
-        self._availability_failure_limit polls in a row."""
+        self._availability_failure_limit polls in a row.
+
+        Return True only when the failure threshold is first reached or a
+        later successful poll recovers from that threshold. Keeping the
+        counter saturated while offline prevents a long outage from looking
+        like a new transition every few polls.
+        """
         if available:
+            became_available = (
+                self._consecutive_failures >= self._availability_failure_limit
+            )
             self._consecutive_failures = 0
             self._available = True
-            return
+            return became_available
 
-        self._consecutive_failures += 1
+        previous_failures = self._consecutive_failures
+        self._consecutive_failures = min(
+            previous_failures + 1, self._availability_failure_limit
+        )
         if self._consecutive_failures >= self._availability_failure_limit:
-            self._consecutive_failures = 0
             self._available = False
+        return (
+            previous_failures < self._availability_failure_limit
+            <= self._consecutive_failures
+        )
+
+    def _record_connection_failure(self, error: BaseException) -> None:
+        """Count and log one failed poll without flooding the regular log."""
+        became_unavailable = self._set_availability(False)
+        if became_unavailable:
+            _LOGGER.warning(
+                "Airco [%s] is unavailable after %s failed polls",
+                self.device_name,
+                self._availability_failure_limit,
+            )
+            _LOGGER.debug("Update of [%s] failed", self.device_name, exc_info=error)
+        else:
+            _LOGGER.debug(
+                "Could not reach the airco [%s]: %s", self.device_name, error
+            )
 
     def set_available(self, available: bool):
         """Set available status"""
@@ -668,13 +693,15 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         try:
             async with asyncio.timeout(POLL_TIMEOUT.total_seconds()):
                 await asyncio.gather(*[self.update()])
-        except asyncio.TimeoutError as error:
-            # Spelled out because str(TimeoutError()) is empty: the
-            # coordinator's own message would otherwise read "Error fetching
-            # <name> data:" and stop there, which says nothing at all.
-            raise UpdateFailed(
-                f"[{self.device_name}] did not answer within "
-                f"{POLL_TIMEOUT.total_seconds():.0f}s"
-            ) from error
+        except asyncio.TimeoutError:
+            # The outer deadline can expire before the repository's individual
+            # connection attempts do. Treat that exactly like any other missed
+            # poll so transient outages stay quiet and the entity only becomes
+            # unavailable at the configured threshold.
+            self._record_connection_failure(
+                AirconConnectionError(
+                    f"did not answer within {POLL_TIMEOUT.total_seconds():.0f}s"
+                )
+            )
         except Exception as error:
             raise UpdateFailed(error) from error

--- a/custom_components/mitsubishi_wf_rac/wfrac/repository.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/repository.py
@@ -96,8 +96,11 @@ class Repository:
         self._session = async_get_clientsession(hass)
         self._next_request_after = datetime.now()
         # Previously-discovered communication method (http/https), if the caller
-        # persisted one from a prior run - skips rediscovery below.
+        # persisted one from a prior run - skips rediscovery below. Keep it as
+        # the preferred method as well: if a transport outage invalidates the
+        # active method, rediscovery must try the last successful one first.
         self._method: str | None = method if method in ("http", "https") else None
+        self._preferred_method = self._method
         self._ssl_context: ssl.SSLContext | None = None
         # Serializes _post() calls so the min-time-between-requests throttle and
         # the method-discovery/reset logic below can't interleave across
@@ -208,34 +211,51 @@ class Repository:
                     # request an extra discovery round trip for nothing.
                     raise
                 except AirconConnectionError:
-                    # A transport outage says nothing about the protocol. In
-                    # particular, dropping a known HTTPS method while the unit
-                    # is powered off makes the next poll try HTTP discovery
-                    # first. Some HTTPS units accept that connection without
-                    # answering, so the coordinator's overall timeout expires
-                    # before HTTPS is reached and recovery wedges indefinitely.
-                    # Keep the last method that actually worked and retry it on
-                    # the next poll.
+                    # A transport outage may mean either that the unit is down
+                    # or that its firmware now uses the other protocol. Clear
+                    # the active method so rediscovery remains possible, while
+                    # retaining it as the preferred first attempt below. This
+                    # lets an unchanged HTTPS unit recover without getting
+                    # stuck on an HTTP-first discovery attempt.
+                    self._preferred_method = self._method
+                    self._method = None
                     raise
 
             # If we haven't yet determined if https is required, find out
             else:
                 _LOGGER.debug("No stored method; attempting discovery...")
-                try:
-                    # Deliberately falls back on any error, command errors
-                    # included: an HTTPS-only module can answer a plaintext
-                    # request with a status code rather than dropping the
-                    # connection, and that still means "try the other one".
-                    json_response = await _execute_request("http")
-                    _LOGGER.info("Discovered working communication method: HTTP")
-                    # Store the required communication method
-                    self._method = "http"
-                except AirconApiError:
-                    _LOGGER.debug("HTTP failed, trying HTTPS")
-                    json_response = await _execute_request("https")
-                    _LOGGER.info("Discovered working communication method: HTTPS")
-                    # Store the required communication method
-                    self._method = "https"
+                methods = (
+                    (self._preferred_method,)
+                    if self._preferred_method in ("http", "https")
+                    else ()
+                )
+                methods += tuple(
+                    method for method in ("http", "https") if method not in methods
+                )
+
+                # Fall back on any API error, command errors included: a unit
+                # can answer the wrong protocol with a status code rather than
+                # dropping the connection, which still means "try the other
+                # one".
+                for index, method in enumerate(methods):
+                    try:
+                        json_response = await _execute_request(method)
+                    except AirconApiError:
+                        if index == len(methods) - 1:
+                            raise
+                        _LOGGER.debug(
+                            "%s failed, trying %s",
+                            method.upper(),
+                            methods[index + 1].upper(),
+                        )
+                        continue
+
+                    _LOGGER.info(
+                        "Discovered working communication method: %s", method.upper()
+                    )
+                    self._method = method
+                    self._preferred_method = method
+                    break
 
             self._next_request_after = datetime.now() + _MIN_TIME_BETWEEN_REQUESTS
 

--- a/custom_components/mitsubishi_wf_rac/wfrac/repository.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/repository.py
@@ -207,17 +207,15 @@ class Repository:
                     # Discarding the method here would cost every later
                     # request an extra discovery round trip for nothing.
                     raise
-                except AirconApiError:
-                    # The unit may have rebooted, changed protocol, or the
-                    # persisted method from a previous run may simply be stale -
-                    # reset so the next request rediscovers instead of wedging
-                    # itself permanently against a method that no longer works.
-                    _LOGGER.info(
-                        "Request with stored method %r failed; "
-                        "resetting so the next request rediscovers",
-                        self._method,
-                    )
-                    self._method = None
+                except AirconConnectionError:
+                    # A transport outage says nothing about the protocol. In
+                    # particular, dropping a known HTTPS method while the unit
+                    # is powered off makes the next poll try HTTP discovery
+                    # first. Some HTTPS units accept that connection without
+                    # answering, so the coordinator's overall timeout expires
+                    # before HTTPS is reached and recovery wedges indefinitely.
+                    # Keep the last method that actually worked and retry it on
+                    # the next poll.
                     raise
 
             # If we haven't yet determined if https is required, find out

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -118,21 +118,101 @@ async def test_update_api_error_marks_unavailable_and_reregisters(device):
     device._api.update_account_info.assert_awaited_once()
 
 
-async def test_update_unreachable_does_not_reregister(device, caplog):
+async def test_update_transient_unreachable_is_debug_only(device, caplog):
     """An account can only have been evicted by a unit that answered - after a
     bare connection failure there is nothing to re-register against, and the
     hourly WiFi restart these modules do would make it a recurring no-op.
     """
+    caplog.set_level("DEBUG", logger=device_module.__name__)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    caplog.clear()
+
     device._api.get_aircon_stats.side_effect = AirconConnectionError("no route")
     device._api.update_account_info = AsyncMock()
     await device.update()
-    assert device.available is False
+
+    assert device.available is True
     device._api.update_account_info.assert_not_awaited()
-    # One line for the user; the trace stays available on debug.
-    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    records = [r for r in caplog.records if r.name == device_module.__name__]
+    assert not [r for r in records if r.levelname == "WARNING"]
+    assert len(records) == 1
+    assert records[0].levelname == "DEBUG"
+    assert records[0].exc_info is None
+
+    caplog.clear()
+    device._api.get_aircon_stats.side_effect = None
+    await device.update()
+    assert not [r for r in caplog.records if "is available again" in r.message]
+
+
+async def test_update_sustained_unreachable_logs_one_transition(device, caplog):
+    caplog.set_level("DEBUG", logger=device_module.__name__)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    caplog.clear()
+
+    device._api.get_aircon_stats.side_effect = AirconConnectionError("no route")
+    device._api.update_account_info = AsyncMock()
+    for _ in range(10):
+        await device.update()
+
+    assert device.available is False
+    assert device._consecutive_failures == device._availability_failure_limit
+    device._api.update_account_info.assert_not_awaited()
+    warnings = [
+        r
+        for r in caplog.records
+        if r.name == device_module.__name__ and r.levelname == "WARNING"
+    ]
     assert len(warnings) == 1
+    assert "is unavailable after 3 failed polls" in warnings[0].message
     assert warnings[0].exc_info is None
-    assert any(r.exc_info for r in caplog.records if r.levelname == "DEBUG")
+    assert sum(
+        r.exc_info is not None
+        for r in caplog.records
+        if r.name == device_module.__name__ and r.levelname == "DEBUG"
+    ) == 1
+
+
+async def test_update_initially_unreachable_logs_threshold_once(device, caplog):
+    """An unavailable device at startup still has a distinct threshold event,
+    even though its public availability flag starts out false.
+    """
+    device._api.get_aircon_stats.side_effect = AirconConnectionError("no route")
+    device._api.update_account_info = AsyncMock()
+    for _ in range(5):
+        await device.update()
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.name == device_module.__name__ and r.levelname == "WARNING"
+    ]
+    assert len(warnings) == 1
+    assert "is unavailable after 3 failed polls" in warnings[0].message
+
+
+async def test_update_recovery_is_logged_once(device, caplog):
+    caplog.set_level("INFO", logger=device_module.__name__)
+    device._api.get_aircon_stats.side_effect = AirconConnectionError("no route")
+    for _ in range(3):
+        await device.update()
+
+    device._api.get_aircon_stats.side_effect = None
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    await device.update()
+
+    assert device.available is True
+    recoveries = [
+        r
+        for r in caplog.records
+        if r.name == device_module.__name__
+        and r.levelname == "INFO"
+        and "is available again" in r.message
+    ]
+    assert len(recoveries) == 1
 
 
 async def test_update_refused_command_reregisters(device):
@@ -305,7 +385,9 @@ async def test_async_queue_command_notifies_listeners_even_on_failure(device, mo
     monkeypatch.setattr(device_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
     device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
     await device.update()
-    device._api.send_airco_command = AsyncMock(side_effect=AirconApiError("boom"))
+    device._api.send_airco_command = AsyncMock(
+        side_effect=AirconConnectionError("offline")
+    )
 
     listener = MagicMock()
     unsubscribe = device.async_add_listener(listener)
@@ -627,23 +709,29 @@ async def test_async_update_data_wraps_exception_in_update_failed(device):
         await device._async_update_data()
 
 
-async def test_async_update_data_names_the_timeout(device, monkeypatch):
-    """str(TimeoutError()) is empty, so without a message of our own the
-    coordinator logs "Error fetching <name> data:" and nothing else.
-    """
-    from homeassistant.helpers.update_coordinator import UpdateFailed
-
+async def test_async_update_data_counts_timeouts_as_connection_failures(
+    device, monkeypatch, caplog
+):
     monkeypatch.setattr(device_module, "POLL_TIMEOUT", timedelta(milliseconds=10))
+    caplog.set_level("DEBUG", logger=device_module.__name__)
 
     async def _hang():
         await asyncio.sleep(5)
 
     device.update = _hang
-    with pytest.raises(UpdateFailed) as excinfo:
+    for _ in range(5):
         await device._async_update_data()
 
-    assert str(excinfo.value)
-    assert "did not answer" in str(excinfo.value)
+    assert device.available is False
+    assert device._consecutive_failures == device._availability_failure_limit
+    warnings = [
+        record
+        for record in caplog.records
+        if record.name == device_module.__name__ and record.levelname == "WARNING"
+    ]
+    assert len(warnings) == 1
+    assert "is unavailable after 3 failed polls" in warnings[0].message
+    assert sum("did not answer within" in record.message for record in caplog.records) == 4
 
 
 # --- service data is carried between polls, but not forever ---------------

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -7,6 +7,7 @@ than tests/unit/.
 
 import asyncio
 import base64
+import logging
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
@@ -17,7 +18,10 @@ from custom_components.mitsubishi_wf_rac.wfrac.device import (
     AVAILABILITY_FAILURE_LIMIT_MIN,
     Device,
 )
-from custom_components.mitsubishi_wf_rac.wfrac.models.aircon import Aircon, AirconCommands
+from custom_components.mitsubishi_wf_rac.wfrac.models.aircon import (
+    Aircon,
+    AirconCommands,
+)
 from custom_components.mitsubishi_wf_rac.wfrac.rac_parser import RacParser
 from custom_components.mitsubishi_wf_rac.wfrac.repository import (
     AirconApiError,
@@ -99,21 +103,21 @@ async def device(hass):
 
 async def test_update_success_marks_available_and_parses_state(device):
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
-    await device.update()
+    assert await device.update() is True
     assert device.available is True
     assert device.airco.Operation is True
 
 
 async def test_update_none_response_marks_unavailable(device):
     device._api.get_aircon_stats.return_value = None
-    await device.update()
+    assert await device.update() is False
     assert device.available is False
 
 
 async def test_update_api_error_marks_unavailable_and_reregisters(device):
     device._api.get_aircon_stats.side_effect = AirconApiError("boom")
     device._api.update_account_info = AsyncMock()
-    await device.update()
+    assert await device.update() is False
     assert device.available is False
     device._api.update_account_info.assert_awaited_once()
 
@@ -709,20 +713,86 @@ async def test_async_update_data_wraps_exception_in_update_failed(device):
         await device._async_update_data()
 
 
+async def test_coordinator_tracks_transient_failure_without_regular_log_noise(
+    device, caplog
+):
+    caplog.set_level("DEBUG", logger=device_module.__name__)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.async_refresh()
+    caplog.clear()
+
+    device._api.get_aircon_stats.side_effect = AirconConnectionError("no route")
+    await device.async_refresh()
+
+    assert device.last_update_success is False
+    assert device.available is True
+    assert not [
+        record for record in caplog.records if record.levelno >= logging.INFO
+    ]
+
+    caplog.clear()
+    device._api.get_aircon_stats.side_effect = None
+    await device.async_refresh()
+
+    assert device.last_update_success is True
+    assert device.available is True
+    assert not [
+        record for record in caplog.records if record.levelno >= logging.INFO
+    ]
+
+
+async def test_coordinator_notifies_when_device_reaches_unavailable_threshold(device):
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.async_refresh()
+    listener = MagicMock()
+    unsubscribe = device.async_add_listener(listener)
+
+    try:
+        device._api.get_aircon_stats.side_effect = AirconConnectionError("no route")
+        await device.async_refresh()
+        await device.async_refresh()
+        listener.reset_mock()
+
+        await device.async_refresh()
+
+        assert device.available is False
+        listener.assert_called_once()
+    finally:
+        unsubscribe()
+
+
+async def test_coordinator_still_logs_unexpected_failures(device, caplog):
+    caplog.set_level("DEBUG", logger=device_module.__name__)
+
+    async def _boom():
+        raise RuntimeError("unexpected")
+
+    device.update = _boom
+    await device.async_refresh()
+
+    assert device.last_update_success is False
+    assert len([record for record in caplog.records if record.levelname == "ERROR"]) == 1
+
+
 async def test_async_update_data_counts_timeouts_as_connection_failures(
     device, monkeypatch, caplog
 ):
     monkeypatch.setattr(device_module, "POLL_TIMEOUT", timedelta(milliseconds=10))
     caplog.set_level("DEBUG", logger=device_module.__name__)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.async_refresh()
+    original_update = device.update
+    caplog.clear()
 
     async def _hang():
         await asyncio.sleep(5)
 
     device.update = _hang
     for _ in range(5):
-        await device._async_update_data()
+        await device.async_refresh()
 
     assert device.available is False
+    assert device.last_update_success is False
     assert device._consecutive_failures == device._availability_failure_limit
     warnings = [
         record
@@ -731,7 +801,29 @@ async def test_async_update_data_counts_timeouts_as_connection_failures(
     ]
     assert len(warnings) == 1
     assert "is unavailable after 3 failed polls" in warnings[0].message
-    assert sum("did not answer within" in record.message for record in caplog.records) == 4
+    assert not [record for record in caplog.records if record.levelname == "ERROR"]
+    assert sum(
+        record.message.startswith("Could not reach") for record in caplog.records
+    ) == 4
+
+    caplog.clear()
+    device.update = original_update
+    await device.async_refresh()
+    await device.async_refresh()
+
+    assert device.available is True
+    assert device.last_update_success is True
+    recovery_records = [
+        record
+        for record in caplog.records
+        if record.levelname == "INFO" and "available again" in record.message
+    ]
+    assert len(recovery_records) == 1
+    assert not [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.INFO and "data recovered" in record.message
+    ]
 
 
 # --- service data is carried between polls, but not forever ---------------

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -113,13 +113,8 @@ async def test_refused_command_keeps_the_discovered_method(repository):
     ]
 
 
-async def test_unreachable_unit_keeps_the_discovered_method(repository):
-    """An outage must not discard the last protocol that actually worked.
-
-    Otherwise an HTTPS unit can get stuck on the HTTP leg of rediscovery after
-    it comes back, with every attempt cancelled by the coordinator timeout
-    before HTTPS is tried.
-    """
+async def test_rediscovery_tries_the_last_working_method_first(repository):
+    """Recovery must not put an HTTPS unit behind an HTTP-first timeout."""
     repo, session = repository(
         [ClientConnectionError("boom"), _FakeResponse(200, _OK_BODY)],
         method="https",
@@ -128,12 +123,43 @@ async def test_unreachable_unit_keeps_the_discovered_method(repository):
 
     with pytest.raises(AirconConnectionError):
         await repo.get_aircon_stats("airco-id")
-    assert repo.method == "https"
+    assert repo.method is None
 
     await repo.get_aircon_stats("airco-id")
+    assert repo.method == "https"
     assert session.urls == [
         "https://127.0.0.1:51443/beaver/command/getAirconStat",
         "https://127.0.0.1:51443/beaver/command/getAirconStat",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("old_method", "new_method"), (("http", "https"), ("https", "http"))
+)
+async def test_rediscovery_recovers_after_a_protocol_change(
+    repository, old_method, new_method
+):
+    """The alternative remains reachable if a firmware line changes protocol."""
+    repo, session = repository(
+        [
+            ClientConnectionError("unit offline"),
+            ClientConnectionError("old protocol refused"),
+            _FakeResponse(200, _OK_BODY),
+        ],
+        method=old_method,
+    )
+    repo._ssl_context = ssl.create_default_context()
+
+    with pytest.raises(AirconConnectionError):
+        await repo.get_aircon_stats("airco-id")
+
+    await repo.get_aircon_stats("airco-id")
+
+    assert repo.method == new_method
+    assert session.urls == [
+        f"{old_method}://127.0.0.1:51443/beaver/command/getAirconStat",
+        f"{old_method}://127.0.0.1:51443/beaver/command/getAirconStat",
+        f"{new_method}://127.0.0.1:51443/beaver/command/getAirconStat",
     ]
 
 

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -5,7 +5,9 @@ fixture (Repository takes the HA client session from it), hence
 tests/integration/ rather than tests/unit/.
 """
 
+import asyncio
 import json
+import ssl
 from unittest.mock import patch
 
 import pytest
@@ -77,9 +79,19 @@ async def test_http_error_status_raises_command_error(repository):
 
 
 async def test_connection_failure_raises_connection_error(repository):
-    repo, _ = repository([ClientConnectionError("boom")])
-    with pytest.raises(AirconConnectionError):
+    cause = ClientConnectionError("connection refused")
+    repo, _ = repository([cause])
+    with pytest.raises(AirconConnectionError) as error:
         await repo.get_aircon_stats("airco-id")
+    assert error.value.__cause__ is cause
+
+
+async def test_timeout_raises_connection_error(repository):
+    cause = asyncio.TimeoutError()
+    repo, _ = repository([cause])
+    with pytest.raises(AirconConnectionError) as error:
+        await repo.get_aircon_stats("airco-id")
+    assert error.value.__cause__ is cause
 
 
 async def test_refused_command_keeps_the_discovered_method(repository):
@@ -101,15 +113,28 @@ async def test_refused_command_keeps_the_discovered_method(repository):
     ]
 
 
-async def test_unreachable_unit_resets_the_discovered_method(repository):
-    """A dead transport says nothing about which protocol is right, so the
-    stored one is dropped and the next request rediscovers.
+async def test_unreachable_unit_keeps_the_discovered_method(repository):
+    """An outage must not discard the last protocol that actually worked.
+
+    Otherwise an HTTPS unit can get stuck on the HTTP leg of rediscovery after
+    it comes back, with every attempt cancelled by the coordinator timeout
+    before HTTPS is tried.
     """
-    repo, _ = repository([ClientConnectionError("boom")])
+    repo, session = repository(
+        [ClientConnectionError("boom"), _FakeResponse(200, _OK_BODY)],
+        method="https",
+    )
+    repo._ssl_context = ssl.create_default_context()
 
     with pytest.raises(AirconConnectionError):
         await repo.get_aircon_stats("airco-id")
-    assert repo.method is None
+    assert repo.method == "https"
+
+    await repo.get_aircon_stats("airco-id")
+    assert session.urls == [
+        "https://127.0.0.1:51443/beaver/command/getAirconStat",
+        "https://127.0.0.1:51443/beaver/command/getAirconStat",
+    ]
 
 
 async def test_discovery_falls_back_to_https_on_a_command_error(repository):


### PR DESCRIPTION
## Problem

Temporary connection losses currently produce repeated warnings and may
bypass the configured availability threshold when the coordinator's
30-second timeout expires.

A transport failure also discards the last working communication method.
For HTTPS units, the following HTTP-first rediscovery can consume the
entire coordinator timeout before HTTPS is attempted, preventing automatic
recovery after the unit comes back online.

## Changes

- Count connection failures and coordinator timeouts as failed polls.
- Keep transient failures at debug level.
- Mark the device unavailable only after the configured failure threshold.
- Emit one warning when the device transitions to unavailable.
- Saturate the failure counter to prevent repeated warnings during a longer outage.
- Log one recovery message after the first successful poll.
- Preserve the last working HTTP/HTTPS method during transport outages.
- Keep account re-registration limited to API errors from a responding unit.
- Add regression tests for transient outages, sustained outages, startup
  failures, timeouts, recovery, and communication-method retention.

## Validation

- 180 tests passed.
- Python compilation completed successfully.
- Ruff E9/F checks passed.
- `git diff --check` passed.
- Live Home Assistant test:
  - one warning after three failed polls;
  - the climate entity became unavailable;
  - no repeated warning on subsequent failed polls;
  - no coordinator, account, or legacy update errors;
  - automatic recovery after restoring power, without reloading the integration.

Related to #173. This improves handling and recovery when connectivity is
lost; it does not claim to eliminate network interruptions caused by the unit.