### PR TITLE
Give a poll room for both discovery legs

### DIFF
--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -11,6 +11,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .firmware_check import fetch_latest_firmware
 from .rac_parser import RacParser
 from .repository import (
+    MIN_TIME_BETWEEN_REQUESTS,
+    REQUEST_TIMEOUT,
     AirconApiError,
     AirconCommandError,
     AirconConnectionError,
@@ -73,10 +75,19 @@ SERVICE_DATA_FIELDS = (
     "EevPosition",
 )
 
-# Matches the underlying HTTP request timeout. The WF-RAC adapter is slow and
-# frequently answers in 10-20s; a tighter coordinator timeout would cancel
-# slow-but-valid polls and report a device that was about to answer as failed.
-POLL_TIMEOUT = timedelta(seconds=30)
+# Room for both legs of protocol discovery plus the minimum spacing between
+# requests, so a poll that has to fall back to the other protocol is not
+# cancelled halfway through.
+#
+# It used to equal the per-request timeout, and that combination has a trap
+# (#236): a unit that accepts a plaintext connection without answering it
+# consumes the whole window on the first leg, so the second protocol is never
+# reached. If that unit only speaks the second protocol, every poll fails the
+# same way and the device never recovers on its own.
+#
+# Stays under MIN_TIME_BETWEEN_UPDATES so a slow poll cannot still be running
+# when the next one is due.
+POLL_TIMEOUT = 2 * REQUEST_TIMEOUT + MIN_TIME_BETWEEN_REQUESTS + timedelta(seconds=4)
 
 # Consecutive failed polls before the device is reported unavailable, and the
 # floor under the configurable value. The module reassociates to WiFi about

--- a/custom_components/mitsubishi_wf_rac/wfrac/repository.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/repository.py
@@ -25,9 +25,16 @@ _HTTP_LOG = _LOGGER.getChild("http")
 
 # ensure that we don't overwhelm the aircon unit by waiting at least
 # this long between successive requests
-_MIN_TIME_BETWEEN_REQUESTS = timedelta(seconds=1)
+MIN_TIME_BETWEEN_REQUESTS = timedelta(seconds=1)
 
-_REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=30)
+# Ceiling for a single request. The adapter is slow and frequently answers in
+# 10-20s, so this cannot be tightened much - but it must leave room for a
+# second attempt inside the same coordinator poll, because discovery tries one
+# protocol and then the other. Device.POLL_TIMEOUT is derived from it; see the
+# note there for what happens when the two are equal.
+REQUEST_TIMEOUT = timedelta(seconds=25)
+
+_REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT.total_seconds())
 
 
 def _create_permissive_ssl_context() -> ssl.SSLContext:
@@ -239,7 +246,7 @@ class Repository:
                     # Store the required communication method
                     self._method = "https"
 
-            self._next_request_after = datetime.now() + _MIN_TIME_BETWEEN_REQUESTS
+            self._next_request_after = datetime.now() + MIN_TIME_BETWEEN_REQUESTS
 
         _HTTP_LOG.debug(
             "Got response from %r: %r",

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -11,7 +11,11 @@ from unittest.mock import patch
 import pytest
 from aiohttp import ClientConnectionError
 
+from custom_components.mitsubishi_wf_rac.const import MIN_TIME_BETWEEN_UPDATES
+from custom_components.mitsubishi_wf_rac.wfrac.device import POLL_TIMEOUT
 from custom_components.mitsubishi_wf_rac.wfrac.repository import (
+    MIN_TIME_BETWEEN_REQUESTS,
+    REQUEST_TIMEOUT,
     AirconCommandError,
     AirconConnectionError,
     Repository,
@@ -127,3 +131,22 @@ async def test_discovery_falls_back_to_https_on_a_command_error(repository):
         "http://127.0.0.1:51443/beaver/command/getAirconStat",
         "https://127.0.0.1:51443/beaver/command/getAirconStat",
     ]
+
+
+# --- the two timeouts have to relate to each other -----------------------
+
+
+def test_a_poll_has_room_for_both_discovery_legs():
+    """Discovery tries one protocol and then the other inside a single poll.
+
+    When the per-request and per-poll timeouts were equal, a unit that accepts
+    a connection without answering it consumed the whole window on the first
+    leg, so the second protocol was never reached - and a unit that only
+    speaks the second one could never recover (#236).
+    """
+    assert POLL_TIMEOUT >= 2 * REQUEST_TIMEOUT + MIN_TIME_BETWEEN_REQUESTS
+
+
+def test_a_poll_cannot_outlive_its_own_interval():
+    """Otherwise a slow poll is still running when the next one is due."""
+    assert POLL_TIMEOUT < MIN_TIME_BETWEEN_UPDATES


### PR DESCRIPTION
Follows from @SoftwareSchmied's finding in #236, and fixes the part of it that is ours rather than theirs.

The per-request timeout and the coordinator's per-poll timeout were **both 30 seconds**, which leaves a poll with room for exactly one attempt. Protocol discovery needs two: it tries one protocol and falls back to the other. So a unit that accepts a plaintext connection without answering it consumes the entire window on the first leg, the second protocol is never reached, and a unit that only speaks that second protocol can never recover on its own — every poll fails the same way.

The per-request ceiling drops to 25s, which still clears the 10–20s these adapters routinely take, and the poll timeout is derived from it rather than set alongside it: two attempts plus the minimum spacing between requests, plus a little slack. That lands at 55s, still under the 60s poll interval so a slow poll cannot still be running when the next one is due.

Both constants are public now, because the relationship between them is the point rather than either value on its own, and two tests assert it so they cannot silently drift apart again.

This is deliberately independent of #236: it removes the trap regardless of what discovery does with the stored method, so neither change depends on the other landing first.

Tests: 178 pass.