### PR TITLE
Stop dropping a service-data cycle when a poll answers early

### DIFF
--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -43,6 +43,17 @@ FIRMWARE_CHECK_INTERVAL = timedelta(hours=24)
 # regular poll cadence. See Device._maybe_request_service_data().
 SERVICE_DATA_REQUEST_INTERVAL = MIN_TIME_BETWEEN_UPDATES
 
+# The rate limit is a guard against a second request inside the same cycle, not
+# a cadence of its own: the request is scheduled once per poll anyway. It has to
+# stay clear of the poll interval it is measured against, because the stamp is
+# taken when a poll finishes, not when it was due. Polls arrive exactly
+# MIN_TIME_BETWEEN_UPDATES apart, so a poll answering a few milliseconds faster
+# than the one before it leaves marginally less than that between the two
+# stamps - and with the full interval as the limit, that dropped the cycle. On
+# the unit in #230 it cost 6 of 36 cycles of operation data, every one of them
+# short by under 100ms.
+SERVICE_DATA_MIN_SPACING = SERVICE_DATA_REQUEST_INTERVAL * 0.75
+
 # ...but it does matter *where* in the cycle it lands. Issued straight off the
 # back of a poll it reached the module about a second after the getAirconStat
 # (consolidation delay plus the minimum spacing between requests), and modules
@@ -297,7 +308,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
 
     def _maybe_request_service_data(self) -> None:
         """Kick off a background service-data request if due and enabled (see
-        SERVICE_DATA_REQUEST_INTERVAL). Opt-in like the firmware check above,
+        SERVICE_DATA_MIN_SPACING). Opt-in like the firmware check above,
         but for a different reason: this stays on the local network, but it's
         an extra setAirconStat write (see rac_parser.SERVICE_DATA_CODES) on
         top of the regular read-only poll, not just a cheap read.
@@ -311,7 +322,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         now = datetime.now()
         if (
             self._last_service_data_request is not None
-            and now - self._last_service_data_request < SERVICE_DATA_REQUEST_INTERVAL
+            and now - self._last_service_data_request < SERVICE_DATA_MIN_SPACING
         ):
             return
         # Stamped now, not when the request actually goes out, so the offset

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -616,6 +616,27 @@ async def test_update_service_data_request_is_rate_limited(device, monkeypatch):
     device._api.send_airco_command.assert_awaited_once()
 
 
+async def test_service_data_survives_a_poll_that_answered_early(device, monkeypatch):
+    """Polls arrive one interval apart, but the stamp is taken when each one
+    finishes: a poll answering marginally faster than the previous one leaves
+    slightly less than the interval between the two stamps. Measuring the rate
+    limit against the full interval dropped those cycles (#230, 6 of 36 on the
+    reporting unit).
+    """
+    device._service_data_enabled = True
+    _shorten_service_data_timing(monkeypatch)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
+    device._last_service_data_request = datetime.now() - (
+        device_module.SERVICE_DATA_REQUEST_INTERVAL - timedelta(milliseconds=100)
+    )
+
+    await device.update()
+    await asyncio.sleep(0.05)
+
+    device._api.send_airco_command.assert_awaited_once()
+
+
 async def test_async_update_data_wraps_exception_in_update_failed(device):
     from homeassistant.helpers.update_coordinator import UpdateFailed
 


### PR DESCRIPTION
The rate limit guarding the operation-data request was measured against the full poll interval, but the stamp it compares is taken when a poll finishes, not when it was due. Polls arrive exactly one interval apart while their response times vary by a few hundred milliseconds, so a poll that answered faster than the one before it left marginally less than the interval between the two stamps — and the cycle was skipped.

On the unit reported in #230 that cost 6 of 36 cycles of operation data over 37 minutes, every one of them short by under 100ms. Together with the transient HTTP 501 refusals in the same log, roughly a quarter of the data never arrived, which is what makes those sensors look frozen.

Measure against three quarters of the interval instead. The guard exists to keep two requests out of the same cycle — the request is scheduled once per poll anyway, and an overlapping retry is already covered by the in-flight task check above it.