### PR TITLE
Prepare 2026.9.3-beta2 pre-release

### DIFF
--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues",
   "requirements": [],
-  "version": "2026.9.3-beta1",
+  "version": "2026.9.3-beta2",
   "zeroconf": [
     "_beaver._tcp.local."
   ]


### PR DESCRIPTION
Version bump only.

Contents: #239 (the operation-data request is no longer skipped when a poll answers a few milliseconds faster than the one before it — 6 of 36 cycles lost on the unit in #230), #235 (protective-stop codes get descriptions, seven codes added and three corrected, from the databooks shared in #225) and #237 (the per-request timeout and the poll timeout no longer both sit at 30s, which left a poll with room for only one of the two protocol discovery legs).

Pre-release for the same reason as beta1: the parts that matter here can only be confirmed on hardware that shows the problem — see #230.