### PR TITLE
Prepare 2026.9.3 release

### DIFF
--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues",
   "requirements": [],
-  "version": "2026.9.3-beta2",
+  "version": "2026.9.3",
   "zeroconf": [
     "_beaver._tcp.local."
   ]


### PR DESCRIPTION
Version bump only; the code is identical to `2026.9.3-beta2`.

Both reporters in #230 confirm the beta: operation data now arrives on every poll, and the remaining 501 refusals are rare and recover on the retry.