### PR TITLE
Catch the translations up with en.json

### DIFF
--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -39,6 +39,8 @@
         "data": {
           "host": "ホスト（IP）アドレス",
           "availability_retry_limit": "リトライ回数の上限（最小 3）",
+          "firmware_update_check": "ファームウェア更新の確認 (オンライン)",
+          "service_data": "サービスデータ",
           "create_swing_mode_select": "追加のスイングモードセレクターを作成するかどうか。",
           "indoor_offset": "室内オフセット",
           "outdoor_offset": "室外オフセット",
@@ -124,6 +126,48 @@
           "medium": "中",
           "high": "高"
         }
+      },
+      "home_leave_mode": {
+        "name": "留守モード",
+        "state": {
+          "off": "オフ",
+          "away_cool": "留守冷房",
+          "away_heat": "留守暖房"
+        }
+      },
+      "home_leave_cooling_air_flow": {
+        "name": "留守冷房 風量",
+        "state": {
+          "auto": "自動",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4"
+        }
+      },
+      "home_leave_heating_air_flow": {
+        "name": "留守暖房 風量",
+        "state": {
+          "auto": "自動",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4"
+        }
+      }
+    },
+    "number": {
+      "home_leave_cooling_temp_rule": {
+        "name": "留守冷房 外気温しきい値"
+      },
+      "home_leave_cooling_temp_setting": {
+        "name": "留守冷房 目標室温"
+      },
+      "home_leave_heating_temp_rule": {
+        "name": "留守暖房 外気温しきい値"
+      },
+      "home_leave_heating_temp_setting": {
+        "name": "留守暖房 目標室温"
       }
     },
     "sensor": {
@@ -173,7 +217,25 @@
         "name": "Cool Hot Judge"
       },
       "energy_usage": {
-        "name": "エネルギー使用量"
+        "name": "エネルギー使用量 (今回の運転)"
+      },
+      "energy_usage_total": {
+        "name": "エネルギー使用量 合計"
+      },
+      "compressor_frequency": {
+        "name": "圧縮機周波数"
+      },
+      "operating_current": {
+        "name": "運転電流"
+      },
+      "hot_gas_temp": {
+        "name": "吐出ガス温度"
+      },
+      "eev_pulses": {
+        "name": "電子膨張弁パルス"
+      },
+      "eev_position": {
+        "name": "電子膨張弁開度"
       }
     },
     "binary_sensor": {
@@ -182,11 +244,19 @@
       },
       "occupancy": {
         "name": "在室"
+      },
+      "compressor": {
+        "name": "圧縮機要求"
       }
     },
-    "switch": {
-      "home_leave_mode": {
-        "name": "留守モード"
+    "update": {
+      "firmware_update": {
+        "name": "ファームウェア更新"
+      }
+    },
+    "button": {
+      "reset_energy_total": {
+        "name": "エネルギー使用量 合計をリセット"
       }
     }
   }

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -39,6 +39,8 @@
         "data": {
           "host": "Host (IP) adresas",
           "availability_retry_limit": "Pakartotinio bandymo limitas (min. 3)",
+          "firmware_update_check": "Programinės įrangos atnaujinimų tikrinimas (internetu)",
+          "service_data": "Serviso duomenys",
           "create_swing_mode_select": "Ar kurti papildomus svyravimo režimo pasirinkiklius.",
           "indoor_offset": "Vidaus poslinkis",
           "outdoor_offset": "Lauko poslinkis",
@@ -124,6 +126,48 @@
           "medium": "Vidutinis",
           "high": "Aukštas"
         }
+      },
+      "home_leave_mode": {
+        "name": "Išvykimo režimas",
+        "state": {
+          "off": "Išjungta",
+          "away_cool": "Išvykus vėsinimas",
+          "away_heat": "Išvykus šildymas"
+        }
+      },
+      "home_leave_cooling_air_flow": {
+        "name": "Išvykus vėsinimo oro srautas",
+        "state": {
+          "auto": "Automatinis",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4"
+        }
+      },
+      "home_leave_heating_air_flow": {
+        "name": "Išvykus šildymo oro srautas",
+        "state": {
+          "auto": "Automatinis",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4"
+        }
+      }
+    },
+    "number": {
+      "home_leave_cooling_temp_rule": {
+        "name": "Išvykus vėsinimo lauko temp. riba"
+      },
+      "home_leave_cooling_temp_setting": {
+        "name": "Išvykus vėsinimo tikslinė kambario temp."
+      },
+      "home_leave_heating_temp_rule": {
+        "name": "Išvykus šildymo lauko temp. riba"
+      },
+      "home_leave_heating_temp_setting": {
+        "name": "Išvykus šildymo tikslinė kambario temp."
       }
     },
     "sensor": {
@@ -173,7 +217,25 @@
         "name": "Cool Hot Judge"
       },
       "energy_usage": {
-        "name": "Energijos suvartojimas"
+        "name": "Energijos suvartojimas (dabartinis ciklas)"
+      },
+      "energy_usage_total": {
+        "name": "Bendras energijos suvartojimas"
+      },
+      "compressor_frequency": {
+        "name": "Kompresoriaus dažnis"
+      },
+      "operating_current": {
+        "name": "Darbinė srovė"
+      },
+      "hot_gas_temp": {
+        "name": "Karštų dujų temperatūra"
+      },
+      "eev_pulses": {
+        "name": "EEV impulsai"
+      },
+      "eev_position": {
+        "name": "EEV padėtis"
       }
     },
     "binary_sensor": {
@@ -182,11 +244,19 @@
       },
       "occupancy": {
         "name": "Užimtumas"
+      },
+      "compressor": {
+        "name": "Kompresoriaus poreikis"
       }
     },
-    "switch": {
-      "home_leave_mode": {
-        "name": "Išvykimo režimas"
+    "update": {
+      "firmware_update": {
+        "name": "Programinės įrangos atnaujinimas"
+      }
+    },
+    "button": {
+      "reset_energy_total": {
+        "name": "Atstatyti bendrą energijos suvartojimą"
       }
     }
   }

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -39,6 +39,8 @@
         "data": {
           "host": "Host (IP) address",
           "availability_retry_limit": "Herhaal limiet (minimaal 3)",
+          "firmware_update_check": "Firmware-updatecontrole (online)",
+          "service_data": "Servicegegevens",
           "create_swing_mode_select": "Of er extra zwaaimodus-selectors moeten worden aangemaakt.",
           "indoor_offset": "Binnen offset",
           "outdoor_offset": "Buiten offset",
@@ -124,6 +126,48 @@
           "medium": "Gemiddeld",
           "high": "Hoog"
         }
+      },
+      "home_leave_mode": {
+        "name": "Afwezigheidsmodus",
+        "state": {
+          "off": "Uit",
+          "away_cool": "Afwezig koelen",
+          "away_heat": "Afwezig verwarmen"
+        }
+      },
+      "home_leave_cooling_air_flow": {
+        "name": "Afwezig koelen ventilatorstand",
+        "state": {
+          "auto": "Auto",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4"
+        }
+      },
+      "home_leave_heating_air_flow": {
+        "name": "Afwezig verwarmen ventilatorstand",
+        "state": {
+          "auto": "Auto",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4"
+        }
+      }
+    },
+    "number": {
+      "home_leave_cooling_temp_rule": {
+        "name": "Afwezig koelen buitentemperatuurdrempel"
+      },
+      "home_leave_cooling_temp_setting": {
+        "name": "Afwezig koelen doelkamertemperatuur"
+      },
+      "home_leave_heating_temp_rule": {
+        "name": "Afwezig verwarmen buitentemperatuurdrempel"
+      },
+      "home_leave_heating_temp_setting": {
+        "name": "Afwezig verwarmen doelkamertemperatuur"
       }
     },
     "sensor": {
@@ -173,7 +217,25 @@
         "name": "Cool Hot Judge"
       },
       "energy_usage": {
-        "name": "Energieverbruik"
+        "name": "Energieverbruik (huidige cyclus)"
+      },
+      "energy_usage_total": {
+        "name": "Energieverbruik totaal"
+      },
+      "compressor_frequency": {
+        "name": "Compressorfrequentie"
+      },
+      "operating_current": {
+        "name": "Bedrijfsstroom"
+      },
+      "hot_gas_temp": {
+        "name": "Heetgastemperatuur"
+      },
+      "eev_pulses": {
+        "name": "EEV-pulsen"
+      },
+      "eev_position": {
+        "name": "EEV-positie"
       }
     },
     "binary_sensor": {
@@ -182,11 +244,19 @@
       },
       "occupancy": {
         "name": "Bezetting"
+      },
+      "compressor": {
+        "name": "Compressorvraag"
       }
     },
-    "switch": {
-      "home_leave_mode": {
-        "name": "Afwezigheidsmodus"
+    "update": {
+      "firmware_update": {
+        "name": "Firmware-update"
+      }
+    },
+    "button": {
+      "reset_energy_total": {
+        "name": "Energieverbruik totaal resetten"
       }
     }
   }

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -39,6 +39,8 @@
         "data": {
           "host": "主机（IP）地址",
           "availability_retry_limit": "重试次数上限（最少 3）",
+          "firmware_update_check": "固件更新检查（在线）",
+          "service_data": "服务数据",
           "create_swing_mode_select": "是否创建额外的摆风模式选择器。",
           "indoor_offset": "室内偏移",
           "outdoor_offset": "室外偏移",
@@ -124,6 +126,48 @@
           "medium": "中速",
           "high": "高速"
         }
+      },
+      "home_leave_mode": {
+        "name": "离家模式",
+        "state": {
+          "off": "关闭",
+          "away_cool": "离家制冷",
+          "away_heat": "离家制热"
+        }
+      },
+      "home_leave_cooling_air_flow": {
+        "name": "离家制冷风量",
+        "state": {
+          "auto": "自动",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4"
+        }
+      },
+      "home_leave_heating_air_flow": {
+        "name": "离家制热风量",
+        "state": {
+          "auto": "自动",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4"
+        }
+      }
+    },
+    "number": {
+      "home_leave_cooling_temp_rule": {
+        "name": "离家制冷室外温度阈值"
+      },
+      "home_leave_cooling_temp_setting": {
+        "name": "离家制冷目标室温"
+      },
+      "home_leave_heating_temp_rule": {
+        "name": "离家制热室外温度阈值"
+      },
+      "home_leave_heating_temp_setting": {
+        "name": "离家制热目标室温"
       }
     },
     "sensor": {
@@ -173,7 +217,25 @@
         "name": "冷热判断"
       },
       "energy_usage": {
-        "name": "能耗"
+        "name": "能耗（当前运行）"
+      },
+      "energy_usage_total": {
+        "name": "能耗总计"
+      },
+      "compressor_frequency": {
+        "name": "压缩机频率"
+      },
+      "operating_current": {
+        "name": "运行电流"
+      },
+      "hot_gas_temp": {
+        "name": "排气温度"
+      },
+      "eev_pulses": {
+        "name": "电子膨胀阀脉冲"
+      },
+      "eev_position": {
+        "name": "电子膨胀阀开度"
       }
     },
     "binary_sensor": {
@@ -182,11 +244,19 @@
       },
       "occupancy": {
         "name": "占用"
+      },
+      "compressor": {
+        "name": "压缩机需求"
       }
     },
-    "switch": {
-      "home_leave_mode": {
-        "name": "离家模式"
+    "update": {
+      "firmware_update": {
+        "name": "固件更新"
+      }
+    },
+    "button": {
+      "reset_energy_total": {
+        "name": "重置能耗总计"
       }
     }
   }

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -39,6 +39,8 @@
         "data": {
           "host": "主機（IP）地址",
           "availability_retry_limit": "重試次數上限（最少 3）",
+          "firmware_update_check": "韌體更新檢查（線上）",
+          "service_data": "服務資料",
           "create_swing_mode_select": "是否建立額外的擺風模式選擇器。",
           "indoor_offset": "室內偏移",
           "outdoor_offset": "室外偏移",
@@ -124,6 +126,48 @@
           "medium": "中速",
           "high": "高速"
         }
+      },
+      "home_leave_mode": {
+        "name": "離家模式",
+        "state": {
+          "off": "關閉",
+          "away_cool": "離家製冷",
+          "away_heat": "離家製熱"
+        }
+      },
+      "home_leave_cooling_air_flow": {
+        "name": "離家製冷風量",
+        "state": {
+          "auto": "自動",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4"
+        }
+      },
+      "home_leave_heating_air_flow": {
+        "name": "離家製熱風量",
+        "state": {
+          "auto": "自動",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4"
+        }
+      }
+    },
+    "number": {
+      "home_leave_cooling_temp_rule": {
+        "name": "離家製冷室外溫度門檻"
+      },
+      "home_leave_cooling_temp_setting": {
+        "name": "離家製冷目標室溫"
+      },
+      "home_leave_heating_temp_rule": {
+        "name": "離家製熱室外溫度門檻"
+      },
+      "home_leave_heating_temp_setting": {
+        "name": "離家製熱目標室溫"
       }
     },
     "sensor": {
@@ -173,7 +217,25 @@
         "name": "冷熱判斷"
       },
       "energy_usage": {
-        "name": "能耗"
+        "name": "能耗（目前運轉）"
+      },
+      "energy_usage_total": {
+        "name": "能耗總計"
+      },
+      "compressor_frequency": {
+        "name": "壓縮機頻率"
+      },
+      "operating_current": {
+        "name": "運轉電流"
+      },
+      "hot_gas_temp": {
+        "name": "排氣溫度"
+      },
+      "eev_pulses": {
+        "name": "電子膨脹閥脈衝"
+      },
+      "eev_position": {
+        "name": "電子膨脹閥開度"
       }
     },
     "binary_sensor": {
@@ -182,11 +244,19 @@
       },
       "occupancy": {
         "name": "佔用"
+      },
+      "compressor": {
+        "name": "壓縮機需求"
       }
     },
-    "switch": {
-      "home_leave_mode": {
-        "name": "離家模式"
+    "update": {
+      "firmware_update": {
+        "name": "韌體更新"
+      }
+    },
+    "button": {
+      "reset_energy_total": {
+        "name": "重置能耗總計"
       }
     }
   }


### PR DESCRIPTION
`nl`, `ja`, `lt`, `zh-Hans` and `zh-Hant` were each missing the same 31 keys — everything added since the home-leave controls, including the `Service Data` and firmware-check options, the operation-data sensors, `Energy Usage Total`, the reset button and the firmware update entity. Home Assistant falls back to English for a missing key, so this showed up as a half-translated UI rather than as an error. `de` was already complete.

Noticed while answering #214, where a Dutch-speaking user could not find the `Service Data` option.

Also in here:

- `energy_usage` still carried its pre-2026.9.2 name in all five files, without the "(current run)" qualifier that distinguishes it from `Energy Usage Total`.
- `entity.switch.home_leave_mode` dropped — home leave is a `select` now, so nothing reads that key.

Every file is now rebuilt in en.json's key order, so a future gap shows up as a plain diff.

**Corrections welcome.** I wrote the Dutch and Chinese strings myself and the Japanese and Lithuanian ones with rather less confidence — particularly the refrigeration terms (hot gas temperature, EEV pulses/position, compressor demand). If you are a native speaker and something reads wrong, a PR or a comment is very welcome.