### PR TITLE
Warn on state changes, not on device behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ visible outage: the device is only reported unavailable after three consecutive 
 three minutes, which rides through the reassociation. If your link is weak enough that this still
 shows up, raise **Retry limit** in the options; three is the minimum, not a target.
 
+A missed poll is not logged as a warning either — it is a debug line, and the log only speaks up
+when the device actually crosses the threshold and again when it comes back. Turn on debug logging
+for `custom_components.mitsubishi_wf_rac` if you want to watch the individual polls.
+
 ## Unit goes unavailable for about an hour
 
 This is the same hourly reassociation as above, but the module fails to re-bind port `51443`

--- a/custom_components/mitsubishi_wf_rac/entity.py
+++ b/custom_components/mitsubishi_wf_rac/entity.py
@@ -30,9 +30,10 @@ class WfRacEntity(CoordinatorEntity[Device]):
     @property
     def available(self) -> bool:
         # Device tracks its own retry-tolerant availability (see
-        # Device._set_availability()). The coordinator reports every failed
-        # poll through last_update_success, while entities deliberately remain
-        # available until the device's failure threshold is reached.
+        # Device._set_availability()), and entities follow that rather than the
+        # coordinator's last_update_success: an expected missed poll leaves the
+        # coordinator successful on purpose, so this is the only thing that
+        # decides whether entities go unavailable.
         return self._device.available
 
     @callback

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -111,35 +111,6 @@ POLL_TIMEOUT = 2 * REQUEST_TIMEOUT + MIN_TIME_BETWEEN_REQUESTS + timedelta(secon
 AVAILABILITY_FAILURE_LIMIT_MIN = 3
 
 
-class _ExpectedPollError(UpdateFailed):
-    """A failed device poll already handled by the availability policy."""
-
-
-class _CoordinatorLogger(logging.LoggerAdapter):
-    """Keep expected transient poll failures out of the regular error log."""
-
-    def __init__(self, logger: logging.Logger) -> None:
-        super().__init__(logger, {})
-        self._quiet_failure_pending_recovery = False
-
-    def error(self, msg, *args, **kwargs) -> None:
-        if args and isinstance(args[-1], _ExpectedPollError):
-            self._quiet_failure_pending_recovery = True
-            self.debug(msg, *args, **kwargs)
-            return
-        super().error(msg, *args, **kwargs)
-
-    def info(self, msg, *args, **kwargs) -> None:
-        if (
-            msg == "Fetching %s data recovered"
-            and self._quiet_failure_pending_recovery
-        ):
-            self._quiet_failure_pending_recovery = False
-            self.debug(msg, *args, **kwargs)
-            return
-        super().info(msg, *args, **kwargs)
-
-
 class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attributes
     """Device Class"""
 
@@ -188,6 +159,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         self._service_data_enabled = service_data_enabled
         self._last_service_data_request: datetime | None = None
         self._last_service_data_response: datetime | None = None
+        self._service_data_expired = False
         self._service_data_task: asyncio.Task | None = None
         self._consecutive_failures = 0
         # Clamped rather than validated: an entry can carry a lower value from
@@ -207,7 +179,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
 
         super().__init__(
             hass,
-            _CoordinatorLogger(_LOGGER),
+            _LOGGER,
             name=name,
             update_interval=MIN_TIME_BETWEEN_UPDATES,
         )
@@ -393,7 +365,12 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
                     _LOGGER.debug("Service data request refused (%s); retrying", ex)
                     await asyncio.sleep(SERVICE_DATA_RETRY_DELAY.total_seconds())
                     continue
-                _LOGGER.warning(
+                # Debug, not a warning: the module refuses these requests
+                # transiently and a single skipped cycle changes nothing the
+                # user can see - the values survive SERVICE_DATA_MAX_AGE. The
+                # warning belongs where they actually expire, see
+                # _note_service_data_expired().
+                _LOGGER.debug(
                     "Service data request refused twice, skipping this cycle "
                     "for [%s]: %s",
                     self.device_name,
@@ -419,16 +396,48 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         now = datetime.now()
         if any(getattr(new_airco, name) is not None for name in SERVICE_DATA_FIELDS):
             self._last_service_data_response = now
+            if self._service_data_expired:
+                self._service_data_expired = False
+                _LOGGER.info(
+                    "Operation data from [%s] is being reported again",
+                    self.device_name,
+                )
         elif (
             self._last_service_data_response is None
             or now - self._last_service_data_response > SERVICE_DATA_MAX_AGE
         ):
             # Nothing fresh for too long - leave the fields unset so entities
             # report unknown rather than a value that stopped being true.
+            self._note_service_data_expired(now)
             return
         for name in SERVICE_DATA_FIELDS:
             if getattr(new_airco, name) is None:
                 setattr(new_airco, name, getattr(self._airco, name))
+
+    def _note_service_data_expired(self, now: datetime) -> None:
+        """Warn once, when the operation-data sensors actually go unknown.
+
+        A refused request costs a cycle and nothing else, so it stays on debug:
+        at roughly one an hour per unit it would otherwise be a permanent
+        warning about a module behaviour no one can act on. Running out of
+        values is the part a user can see, and it is worth exactly one line -
+        with a matching one when they come back.
+        """
+        if self._service_data_expired:
+            return
+        # Before the first response there is nothing to lose yet; anchor on the
+        # first request instead so a module that never answers is still
+        # reported, once, rather than silently leaving the sensors unknown.
+        anchor = self._last_service_data_response or self._last_service_data_request
+        if anchor is None or now - anchor <= SERVICE_DATA_MAX_AGE:
+            return
+        self._service_data_expired = True
+        _LOGGER.warning(
+            "No operation data from [%s] for over %.0fs; its compressor, "
+            "current, temperature and EEV sensors now report unknown",
+            self.device_name,
+            SERVICE_DATA_MAX_AGE.total_seconds(),
+        )
 
     async def delete_account(self):
         """Delete account (operator id) from the airco"""
@@ -609,7 +618,12 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         )
 
     def _record_connection_failure(self, error: BaseException) -> None:
-        """Count and log one failed poll without flooding the regular log."""
+        """Count one failed poll, and log it at the level it deserves.
+
+        Every poll still reaches entities (_async_update_data returns the last
+        data on an expected failure), so crossing the threshold needs no
+        notification of its own - only the line that says it happened.
+        """
         became_unavailable = self._set_availability(False)
         if became_unavailable:
             _LOGGER.warning(
@@ -618,11 +632,6 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
                 self._availability_failure_limit,
             )
             _LOGGER.debug("Update of [%s] failed", self.device_name, exc_info=error)
-            # The coordinator only notifies listeners when its own success
-            # state changes. It already changed on the first missed poll, so
-            # reaching our later device-availability threshold would otherwise
-            # leave entities displaying their restored/last-known state.
-            self.async_update_listeners()
         else:
             _LOGGER.debug(
                 "Could not reach the airco [%s]: %s", self.device_name, error
@@ -746,22 +755,32 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         return self._api.method
 
     async def _async_update_data(self):
-        """Update data via library."""
+        """Update data via library.
+
+        A missed poll is not an update failure. These modules restart their
+        WiFi about once an hour on their own, so single failures are routine
+        and carry no consequence: _set_availability() rides them out, and
+        entities follow Device.available rather than the coordinator's own
+        success flag. Raising UpdateFailed for one would put an error in every
+        user's log once an hour for a condition nobody can act on - and the
+        entities would flick to unavailable a poll before our own threshold
+        says they should. So an expected failure returns the last data instead,
+        and only the availability transition is worth a line.
+        """
         try:
             async with asyncio.timeout(POLL_TIMEOUT.total_seconds()):
-                update_succeeded = await self.update()
+                await self.update()
         except asyncio.TimeoutError as error:
             # The outer deadline can expire before the repository's individual
             # connection attempts do. Treat that exactly like any other missed
             # poll so transient outages stay quiet and the entity only becomes
             # unavailable at the configured threshold.
-            connection_error = AirconConnectionError(
-                f"did not answer within {POLL_TIMEOUT.total_seconds():.0f}s"
+            self._record_connection_failure(
+                AirconConnectionError(
+                    f"did not answer within {POLL_TIMEOUT.total_seconds():.0f}s"
+                )
             )
-            self._record_connection_failure(connection_error)
-            raise _ExpectedPollError(str(connection_error)) from error
         except Exception as error:
             raise UpdateFailed(error) from error
 
-        if not update_succeeded:
-            raise _ExpectedPollError(f"Poll of [{self.device_name}] failed")
+        return self._airco

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -683,9 +683,12 @@ async def test_service_data_request_gives_up_after_the_retry(device, monkeypatch
     await asyncio.sleep(0.1)
 
     assert device._api.send_airco_command.await_count == 2
-    # One warning for the cycle, not one per attempt.
+    # One line for the cycle, not one per attempt - and on debug, because a
+    # skipped cycle costs the user nothing (see _note_service_data_expired).
     refusals = [r for r in caplog.records if "refused twice" in r.message]
     assert len(refusals) == 1
+    assert refusals[0].levelname == "DEBUG"
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
 
 async def test_update_service_data_request_is_rate_limited(device, monkeypatch):
@@ -745,7 +748,10 @@ async def test_coordinator_tracks_transient_failure_without_regular_log_noise(
     device._api.get_aircon_stats.side_effect = AirconConnectionError("no route")
     await device.async_refresh()
 
-    assert device.last_update_success is False
+    # An expected miss deliberately leaves the coordinator successful: it is
+    # what keeps HA's own "Error fetching ... data" out of the log, and
+    # entity availability comes from Device.available instead.
+    assert device.last_update_success is True
     assert device.available is True
     assert not [
         record for record in caplog.records if record.levelno >= logging.INFO
@@ -777,6 +783,8 @@ async def test_coordinator_notifies_when_device_reaches_unavailable_threshold(de
         await device.async_refresh()
 
         assert device.available is False
+        # The poll that crosses the threshold has to reach entities, or they
+        # keep showing their last state while the device is marked unavailable.
         listener.assert_called_once()
     finally:
         unsubscribe()
@@ -813,7 +821,9 @@ async def test_async_update_data_counts_timeouts_as_connection_failures(
         await device.async_refresh()
 
     assert device.available is False
-    assert device.last_update_success is False
+    # A timeout is an expected miss like any other, so the coordinator stays
+    # successful and only the availability threshold speaks up.
+    assert device.last_update_success is True
     assert device._consecutive_failures == device._availability_failure_limit
     warnings = [
         record
@@ -889,3 +899,43 @@ async def test_fresh_service_data_restarts_the_clock(device):
     assert new_airco.CompressorFrequency == 45.0
     # The rest of the block comes with it, so they are carried again.
     assert new_airco.HotGasTemp == 50.0
+
+
+async def test_expiring_service_data_warns_once_and_reports_the_recovery(
+    device, caplog
+):
+    """The refusals themselves are routine; running out of values is not."""
+    caplog.set_level("DEBUG", logger=device_module.__name__)
+    device._airco.CompressorFrequency = 40.0
+    device._last_service_data_response = datetime.now() - (
+        device_module.SERVICE_DATA_MAX_AGE + timedelta(seconds=1)
+    )
+
+    for _ in range(3):
+        device._carry_forward_service_data(Aircon())
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert "now report unknown" in warnings[0].message
+
+    caplog.clear()
+    recovered = Aircon()
+    recovered.CompressorFrequency = 45.0
+    device._carry_forward_service_data(recovered)
+
+    assert [r.levelname for r in caplog.records if r.levelno >= logging.INFO] == [
+        "INFO"
+    ]
+    assert "being reported again" in caplog.records[-1].message
+
+
+async def test_service_data_that_never_arrived_stays_quiet_until_it_is_due(
+    device, caplog
+):
+    """A unit asked for the first time has nothing to lose yet."""
+    caplog.set_level("DEBUG", logger=device_module.__name__)
+    device._last_service_data_request = datetime.now()
+
+    device._carry_forward_service_data(Aircon())
+
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]


### PR DESCRIPTION
Follow-up to #236, and the other half of #230.

Two routine module behaviours were reaching the regular log about once an hour per unit:

- the WiFi reassociation costs a poll (`Could not reach the airco …`),
- the operation-data request is refused transiently (`Service data request refused twice …`).

Neither has a consequence — a missed poll is absorbed by the availability threshold, a skipped service-data cycle by the carry-forward. So both were warning about something no user can act on, once an hour, indefinitely. That trains people to ignore the log, which costs more than it ever saved.

**The rule from here on: a line is written when the integration's state changes, not when the device does something.**

- An expected missed poll no longer raises `UpdateFailed`. It returns the last data, so the coordinator stays successful and HA's own `Error fetching … data` never appears in the first place; entity availability was already decided by `Device.available` (#236). This removes the need for `_CoordinatorLogger`, which suppressed those lines after the fact by comparing against HA's format string — that breaks silently the day core rewords it, and what comes back then is not the noise but a swallowed recovery message.
- A skipped service-data cycle drops to `debug`. The warning moves to where the values actually expire and the sensors go `unknown` — once per outage, with a matching line when they return. A module that never answers the request at all is still reported, once, anchored on the first attempt.

What still warrants a warning is unchanged: a device that crosses the availability threshold, an unparseable response, an evicted account, a user command that did not reach the unit.

On the two units in #230 this is the difference between roughly 30 warnings a day and none — every one of their outages was a single cycle.

192 tests, including the availability and service-data cases reworked for the new contract and three new ones for the expiry warning.