### PR TITLE
Say so when the unit refuses a command it answered

### DIFF
--- a/custom_components/mitsubishi_wf_rac/wfrac/repository.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/repository.py
@@ -36,6 +36,20 @@ REQUEST_TIMEOUT = timedelta(seconds=25)
 
 _REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT.total_seconds())
 
+# The `result` field every response carries, as the official app reads it.
+# Anything not listed is reported by number alone.
+RESULT_CODES: dict[int, str] = {
+    0: "ok",
+    1: "operator id not registered with the unit",
+    2: "the unit's account table is full",
+    10: "internal error in the air conditioner",
+    11: "internal error in the air conditioner",
+    12: "operation prohibited",
+    20: "firmware update required",
+    99: "the unit did not confirm the command within 30s",
+    429: "too many requests",
+}
+
 
 def _create_permissive_ssl_context() -> ssl.SSLContext:
     """Build a permissive SSL context for units without a known certificate.
@@ -102,6 +116,8 @@ class Repository:
         self._device_id = device_id
         self._session = async_get_clientsession(hass)
         self._next_request_after = datetime.now()
+        # Last refusal reported per command, see _report_result_code().
+        self._refused_commands: dict[str, int] = {}
         # Previously-discovered communication method (http/https), if the caller
         # persisted one from a prior run - skips rediscovery below. Keep it as
         # the preferred method as well: if a transport outage invalidates the
@@ -271,7 +287,42 @@ class Repository:
             self._hostname,
             json_response,
         )
+        self._report_result_code(command, json_response)
         return json_response
+
+    def _report_result_code(self, command: str, response: dict[str, Any]) -> None:
+        """Say so when the unit answers HTTP 200 and still refuses the command.
+
+        Nothing here changes what the caller does with the response. Which
+        firmware reports which code on success over the local API is not
+        established, and a command wrongly treated as failed would be worse
+        than the silent failure this makes visible - reports of "nothing
+        happens, and nothing in the log" (#212) currently have nothing to go
+        on at all.
+
+        One line per command entering a failing state, like everywhere else in
+        this integration: a unit that answers the same refusal every minute
+        would otherwise fill the log with a message the user has already read.
+        """
+        raw = response.get("result")
+        try:
+            code = int(raw)
+        except (TypeError, ValueError):
+            return
+        if code == 0:
+            self._refused_commands.pop(command, None)
+            return
+        if self._refused_commands.get(command) == code:
+            _LOGGER.debug("Aircon still answers %r with result %s", command, code)
+            return
+        self._refused_commands[command] = code
+        _LOGGER.warning(
+            "Aircon answered %r with result %s (%s) - the request was accepted "
+            "but not carried out",
+            command,
+            code,
+            RESULT_CODES.get(code, "meaning unknown"),
+        )
 
     async def get_info(self) -> dict:
         """Simple command to get aircon details"""

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -201,3 +201,44 @@ def test_a_poll_has_room_for_both_discovery_legs():
 def test_a_poll_cannot_outlive_its_own_interval():
     """Otherwise a slow poll is still running when the next one is due."""
     assert POLL_TIMEOUT < MIN_TIME_BETWEEN_UPDATES
+
+
+async def test_refusal_in_the_result_field_is_reported_once(repository, caplog):
+    """HTTP 200 with a non-zero result is a request the unit accepted and did
+    not carry out - invisible until now (#212). Reported, but not acted on:
+    which firmware reports what on success is not established.
+    """
+    caplog.set_level("DEBUG", logger="custom_components.mitsubishi_wf_rac.wfrac.repository")
+    refused = json.dumps({"result": 12, "contents": {"airconStat": "AAA="}})
+    repo, _ = repository(
+        [
+            _FakeResponse(200, refused),
+            _FakeResponse(200, refused),
+            _FakeResponse(200, _OK_BODY),
+            _FakeResponse(200, refused),
+        ]
+    )
+
+    # The caller still gets the response: nothing about the control flow moves.
+    assert await repo.get_aircon_stats("airco-id") == {"airconStat": "AAA="}
+    await repo.get_aircon_stats("airco-id")
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert "result 12 (operation prohibited)" in warnings[0].message
+
+    # A success clears it, so a later refusal is worth saying again.
+    await repo.get_aircon_stats("airco-id")
+    await repo.get_aircon_stats("airco-id")
+
+    assert len([r for r in caplog.records if r.levelname == "WARNING"]) == 2
+
+
+async def test_unknown_result_code_is_still_reported(repository, caplog):
+    repo, _ = repository([_FakeResponse(200, json.dumps({"result": 77, "contents": {}}))])
+
+    await repo.get_aircon_stats("airco-id")
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert "result 77 (meaning unknown)" in warnings[0].message


### PR DESCRIPTION
Every response carries a `result` field, and nothing read it — `repository.py` took the HTTP status as the whole verdict and handed `contents` straight to the caller. A unit that answers `HTTP 200` and then declines to carry the command out passed as a success.

That is exactly what the reports of "nothing happens, and nothing in the log" look like from the inside — [#212](https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues/212), and a case of my own where three `climate.set_temperature` calls reported success and never reached the unit.

The codes come from the official app: `1` operator id not registered, `2` account table full, `10`/`11` internal error, `12` operation prohibited, `20` firmware update required, `99` not confirmed within 30 s, `429` too many requests.

**Logged, not acted on — deliberately.** It is not established that every firmware reports `0` on success over the local API, and a command wrongly treated as failed would be worse than the silent failure this makes visible. What the caller receives does not change. Once the reports show what units actually send, this can grow teeth.

One line per command entering a failing state, repeats on debug, cleared by a success — a unit answering the same refusal every minute must not fill the log with a message that has already been read, which is the rule #245 set.

199 tests, two new.