### PR TITLE
Name both reasons a unit can refuse an account

### DIFF
--- a/custom_components/mitsubishi_wf_rac/wfrac/repository.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/repository.py
@@ -38,10 +38,16 @@ _REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT.total_seconds())
 
 # The `result` field every response carries, as the official app reads it.
 # Anything not listed is reported by number alone.
+#
+# The app reads these on updateAccountInfo, and that is where their wording
+# comes from; the meanings need not be as narrow elsewhere. Code 2 is the one
+# seen so far on setAirconStat, three seconds before the account's own
+# `expires` ran out - the same refusal, but an expired registration rather
+# than a full table, so the message names both.
 RESULT_CODES: dict[int, str] = {
     0: "ok",
     1: "operator id not registered with the unit",
-    2: "the unit's account table is full",
+    2: "the unit refused the account - its table is full, or the registration expired",
     10: "internal error in the air conditioner",
     11: "internal error in the air conditioner",
     12: "operation prohibited",


### PR DESCRIPTION
`result: 2` was reported as "the unit's account table is full". That wording comes from the app's `updateAccountInfo` screen, and the only occurrence seen in the field was on a `setAirconStat`, three seconds before the account's own `expires` ran out — the same refusal, but from an expired registration rather than a full table. Someone reading the old message goes looking for registration slots to free, which is the wrong end of the problem, so it now names both possibilities.

Diagnostic text only; the message itself is new in `2026.9.4-beta1` (#248) and nobody has met it in the wild yet.