### PR TITLE
Finish the Dutch translation

### DIFF
--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -37,7 +37,7 @@
       "init": {
         "description": "Hieronder zijn instellingen die je kan aanpassen voor deze airco.",
         "data": {
-          "host": "Host (IP) address",
+          "host": "Host (IP) adres",
           "availability_retry_limit": "Herhaal limiet (minimaal 3)",
           "firmware_update_check": "Firmware-updatecontrole (online)",
           "service_data": "Servicegegevens",
@@ -214,7 +214,7 @@
         "name": "Modelnummer"
       },
       "cool_hot_judge": {
-        "name": "Cool Hot Judge"
+        "name": "Koel-/verwarmingsstatus"
       },
       "energy_usage": {
         "name": "Energieverbruik (huidige cyclus)"


### PR DESCRIPTION
Two strings stayed English when #244 caught the translations up: the host field in the options flow, and the Cool Hot Judge sensor. Both now read as the rest of the file does.

As with #244, this is my Dutch rather than a native speaker's — corrections welcome, @bert-58 if you happen to see this.