### PR TITLE
Prepare 2026.9.4-beta2 pre-release

### DIFF
--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues",
   "requirements": [],
-  "version": "2026.9.4-beta1",
+  "version": "2026.9.4-beta2",
   "zeroconf": [
     "_beaver._tcp.local."
   ]


### PR DESCRIPTION
Version bump only. Contents: #252 (the operation-data request no longer writes the state back), #253 (`result: 2` names both reasons), #254 (the last two Dutch strings).