### PR TITLE
Prepare the 2026.9.4 release

### DIFF
--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues",
   "requirements": [],
-  "version": "2026.9.4-beta2",
+  "version": "2026.9.4",
   "zeroconf": [
     "_beaver._tcp.local."
   ]


### PR DESCRIPTION
Version bump only. Contents since `2026.9.3`: everything from the two betas, plus #256 (energy-counter resolution documented), #257 (coil sensors converted from the thermistor curve, calibration sensors retired), #259 (source comments) and #262 (the remaining raw byte sensors held back).