### PR TITLE
FUNDING.yml: add GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 buy_me_a_coffee: blues.sechseck
+github: blues-sechseck

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/default)
 [![installbadge]][installs]
 [<img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" height="28">](https://buymeacoffee.com/blues.sechseck)
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/blues-sechseck)
 
 This is a Home Assistant integration for **Mitsubishi Heavy Industries** air conditioners that use
 the WF-RAC WiFi module and the **"Smart M-Air"** app.


### PR DESCRIPTION
Second half of #261 — GitHub Sponsors is now set up, so add the `github:` line alongside Buy Me a Coffee.